### PR TITLE
Adds LDAP Ruby SDK example

### DIFF
--- a/modules/howtos/examples/auth.rb
+++ b/modules/howtos/examples/auth.rb
@@ -21,3 +21,9 @@ Cluster.connect("couchbase://localhost", "Administrator", "password")
 options.authenticator = CertificateAuthenticator.new("/tmp/certificate.pem", "/tmp/private.key")
 Cluster.connect("couchbases://localhost?trust_certificate=/tmp/ca.pem", options)
 # end::auth2[]
+
+# tag::auth3[]
+# Creates a LDAP compatible password authenticator which is INSECURE if not used with TLS (uses PLAIN sasl mechanism).
+options.authenticator = PasswordAuthenticator.ldap_compatible("Administrator", "password")
+Cluster.connect("couchbase://localhost", options)
+# end::auth3[]

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -41,3 +41,7 @@ include::example$auth.rb[tag=auth2,indent=0]
 
 include::6.5@sdk:shared:partial$auth-overview.adoc[tag=ldap]
 
+[source,ruby]
+----
+include::example$auth.rb[tag=auth3,indent=0]
+----


### PR DESCRIPTION
Adds the LDAP ruby SDK code example to the auth documentation, similar to what we have in Java: https://docs.couchbase.com/java-sdk/current/howtos/sdk-authentication.html#ldap