### PR TITLE
Update sdk-common version used to 7.1.2

### DIFF
--- a/modules/concept-docs/pages/buckets-and-clusters.adoc
+++ b/modules/concept-docs/pages/buckets-and-clusters.adoc
@@ -9,7 +9,7 @@ include::project-docs:partial$attributes.adoc[]
 {description}
 
 
-include::{version-server}@sdk:shared:partial$clusters-buckets.adoc[tag=management]
+include::{version-common}@sdk:shared:partial$clusters-buckets.adoc[tag=management]
 
 Management operations in the Ruby SDK may be performed through several interfaces depending on the object:
 

--- a/modules/concept-docs/pages/concepts.adoc
+++ b/modules/concept-docs/pages/concepts.adoc
@@ -3,4 +3,4 @@
 
 include::project-docs:partial$attributes.adoc[]
 
-include::{version-server}@sdk:shared:partial$concepts.adoc[tag=concepts]
+include::{version-common}@sdk:shared:partial$concepts.adoc[tag=concepts]

--- a/modules/concept-docs/pages/data-model.adoc
+++ b/modules/concept-docs/pages/data-model.adoc
@@ -9,7 +9,7 @@ include::project-docs:partial$attributes.adoc[]
 {description}
 Several data structures are supported by the SDK, including map, list, queue, and set.
 
-include::{version-server}@sdk:shared:partial$data-model.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$data-model.adoc[tag=intro]
 
 == Data Structures
 

--- a/modules/concept-docs/pages/documents.adoc
+++ b/modules/concept-docs/pages/documents.adoc
@@ -31,7 +31,7 @@ Although query and path-based (Sub-Document) services are available, the simplic
 
 
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=document]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=document]
 
 == Primitive Key-Value Operations
 
@@ -44,9 +44,9 @@ collection.get(docid)
 collection.remove(docid)
 ----
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=crud-overview]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=crud-overview]
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=store-update]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=store-update]
 
 [NOTE]
 ====
@@ -65,7 +65,7 @@ UPDATE `travel-sample`.inventory.airline SET sale_price = msrp * 0.75 WHERE msrp
 ----
 ====
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=get_generic]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=get_generic]
 
 [source,sql]
 ----
@@ -96,21 +96,21 @@ include::example$documents.rb[tag=lookup-in-projections]
 
 // Counters
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=counters1]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=counters1]
 
 [source,ruby]
 ----
 include::example$documents.rb[tag=counters]
 ----
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=counters2]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=counters2]
 
 [source,ruby]
 ----
 include::example$documents.rb[tag=counters-increment]
 ----
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=counters3]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=counters3]
 
 
 === Use Cases
@@ -120,22 +120,22 @@ This enables you to work with counters using `get()` and `replace()` operations 
 You will find several ways of working with counters https://docs.couchbase.com/sdk-api/couchbase-ruby-client/Couchbase/BinaryCollection.html[in the API docs].
 
 // Expiry
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=expiration]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=expiration]
 
 
 ////
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=]
 ////

--- a/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
+++ b/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
@@ -13,16 +13,16 @@ It is the responsibility of the development team and the software architect to e
 
  
 
-include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=intro]
 
-include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep]
-include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep3]
+include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep]
+include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep3]
 
-include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=older]
+include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=older]
 
-include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=performance]
+include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=performance]
 
-// include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=txns]
+// include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=txns]
 
-// include::{version-server}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=failover]
+// include::{version-common}@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=failover]
 

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -12,16 +12,16 @@ include::project-docs:partial$attributes.adoc[]
 
 == General Approach to Ruby Exceptions
 
-include::{version-server}@sdk:shared:partial$errors.adoc[tag=exception]
+include::{version-common}@sdk:shared:partial$errors.adoc[tag=exception]
 
-// include::{version-server}@sdk:shared:partial$errors.adoc[tag=ref]
+// include::{version-common}@sdk:shared:partial$errors.adoc[tag=ref]
 
-include::{version-server}@sdk:shared:partial$errors.adoc[tag=durability]
+include::{version-common}@sdk:shared:partial$errors.adoc[tag=durability]
 
-include::{version-server}@sdk:shared:partial$errors.adoc[tag=diag]
+include::{version-common}@sdk:shared:partial$errors.adoc[tag=diag]
 
 // Slow Operations Logging
-include::{version-server}@sdk:shared:partial$errors.adoc[tag=observability]
+include::{version-common}@sdk:shared:partial$errors.adoc[tag=observability]
 
 // until opentelemetry release for link below, could add note on API to expose own tracing features?
-// include::{version-server}@sdk:shared:partial$errors.adoc[tag=rto]
+// include::{version-common}@sdk:shared:partial$errors.adoc[tag=rto]

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -9,11 +9,11 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
 
 
 // Prepared Statements for Query Optimization
-include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=prepared]
+include::{version-common}@sdk:shared:partial$n1ql-queries.adoc[tag=prepared]
 
 For the Ruby SDK, the `adhoc` parameter should be set to `false` for a plan to be prepared, or a prepared plan to be reused.
 Do not turn off the `adhoc` flag for _every_ query to Server 6.0 and earlier, since only a finite number of query plans (currently 5000) can be stored in the SDK.
@@ -113,7 +113,7 @@ manager.watch_indexes("travel-sample", ["ix_name", "ix_email", "#primary"], 2_00
 
 
 // Index Consistency
-include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
+include::{version-common}@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
 
 The following options are available:
 

--- a/modules/concept-docs/pages/nonjson.adoc
+++ b/modules/concept-docs/pages/nonjson.adoc
@@ -9,7 +9,7 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$nonjson.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$nonjson.adoc[tag=intro]
 
-include::{version-server}@sdk:shared:partial$nonjson.adoc[tag=using]
+include::{version-common}@sdk:shared:partial$nonjson.adoc[tag=using]
 

--- a/modules/concept-docs/pages/response-time-observability.adoc
+++ b/modules/concept-docs/pages/response-time-observability.adoc
@@ -9,4 +9,4 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$rto.adoc[tag=rto]
+include::{version-common}@sdk:shared:partial$rto.adoc[tag=rto]

--- a/modules/concept-docs/pages/xattr.adoc
+++ b/modules/concept-docs/pages/xattr.adoc
@@ -9,11 +9,11 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
+include::{version-common}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
 
-include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=using_extended_attributes]
+include::{version-common}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=using_extended_attributes]
 
-include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=virtual_extended_attributes]
+include::{version-common}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=virtual_extended_attributes]
 
 [source,ruby]
 ----

--- a/modules/hello-world/pages/sample-application.adoc
+++ b/modules/hello-world/pages/sample-application.adoc
@@ -10,13 +10,13 @@
 
 include::project-docs:partial$attributes.adoc[]
 
-include::{version-server}@sdk:shared:partial$sample-application.adoc[tag=abstract]
+include::{version-common}@sdk:shared:partial$sample-application.adoc[tag=abstract]
 
-include::{version-server}@sdk:shared:partial$sample-application.adoc[tag=quick-start]
+include::{version-common}@sdk:shared:partial$sample-application.adoc[tag=quick-start]
 
-include::{version-server}@sdk:shared:partial$sample-application.adoc[tag=bring-your-own]
+include::{version-common}@sdk:shared:partial$sample-application.adoc[tag=bring-your-own]
 
-include::{version-server}@sdk:shared:partial$sample-application.adoc[tag=using]
+include::{version-common}@sdk:shared:partial$sample-application.adoc[tag=using]
 
 == Sample App Backend
 
@@ -61,7 +61,7 @@ end
 The https://github.com/couchbaselabs/{travel-sample-git-project}/blob/HEAD/{travel-sample-entrypoint}[{travel-sample-entrypoint}] file also contains the functions for handling users, registration, and N1QL queries.
 
 
-include::{version-server}@sdk:shared:partial$sample-application.adoc[tag=data-model]
+include::{version-common}@sdk:shared:partial$sample-application.adoc[tag=data-model]
 
 // TODO: Add this in when we have a swagger endpoint for Ruby
-//include::{version-server}@sdk:shared:partial$sample-application.adoc[tag=rest-api]
+//include::{version-common}@sdk:shared:partial$sample-application.adoc[tag=rest-api]

--- a/modules/howtos/pages/concurrent-document-mutations.adoc
+++ b/modules/howtos/pages/concurrent-document-mutations.adoc
@@ -3,13 +3,13 @@
 include::project-docs:partial$attributes.adoc[]
 :page-aliases: ROOT:concurrent-document-mutations.adoc
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=intro]
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=demo]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=demo]
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=example]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=example]
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=errors]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=errors]
 
 
 [source,ruby]
@@ -20,11 +20,11 @@ include::example$cas.rb[tag=handlingerrors]
 Sometimes more logic is needed when performing updates, for example, if a property is mutually exclusive with another property; only one or the other can exist, but not both.
 
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=performance]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=performance]
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=format]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=format]
 
-include::{version-server}@sdk:shared:partial$cas.adoc[tag=locking]
+include::{version-common}@sdk:shared:partial$cas.adoc[tag=locking]
 
 
 [source,ruby]

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -12,4 +12,4 @@ include::project-docs:partial$attributes.adoc[]
 
 
 Distributed ACID Transactions are not currently available for the Ruby SDK.
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=other]
+include::{version-common}@sdk:shared:partial$acid-transactions.adoc[tag=other]

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -224,7 +224,7 @@ include::example$kv_counter.rb[tag=decrementwithoptions]
 NOTE: Increment & Decrement are considered part of the ‘binary’ API and as such may still be subject to change
 
 
-include::7.1@sdk:shared:partial$atomic.adoc[tag=xdcr]
+include::{version-common}@sdk:shared:partial$atomic.adoc[tag=xdcr]
 
 
 == Scoped KV Operations

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -190,7 +190,7 @@ include::example$kv_operations.rb[tag=expiry-touch]
 ----
 
 
-include::{version-server}@sdk:shared:partial$documents.adoc[tag=exp-note]
+include::{version-common}@sdk:shared:partial$documents.adoc[tag=exp-note]
 
 
 == Atomic Counters

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -173,7 +173,7 @@ E.....@.@.............+....Z.'yZ..#........
 
 
 // DNS-SRV
-include::{version-server}@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv]
+include::{version-common}@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv]
 
 DNS SRV bootstrapping is available in the Ruby SDK from version 3.0.
 In order to make the SDK actually use the SRV records, you need to enable DNS SRV on the environment and pass in the host name from your records (here `example.com`):
@@ -193,7 +193,7 @@ Also, if you pass in more than one node, DNS SRV bootstrap will not be initiated
 
 
 // Cloud connections
-include::{version-server}@sdk:shared:partial$managing-connections.adoc[tag=cloud]
+include::{version-common}@sdk:shared:partial$managing-connections.adoc[tag=cloud]
 
 
 == Further Reading

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -8,7 +8,7 @@ include::project-docs:partial$attributes.adoc[]
 {description}
 Common use cases are outlined here, less common use cases are covered in the https://docs.couchbase.com/sdk-api/couchbase-ruby-client/Couchbase/Management.html[API docs].
 
-include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]
+include::{version-common}@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]
 
 The Ruby SDK also comes with some convenience functionality for common Couchbase management requests.
 
@@ -37,7 +37,7 @@ NOTE: When using a Couchbase version earlier than 6.5, you must create a valid B
 The https://docs.couchbase.com/sdk-api/couchbase-ruby-client/Couchbase/Management/BucketManager.html[BucketManager] interface may be used to create and delete buckets from the Couchbase cluster.
 It is instantiated through the `#create_bucket()` method.
 
-include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=update-bucket-warning]
+include::{version-common}@sdk:shared:partial$flush-info-pars.adoc[tag=update-bucket-warning]
 
 See the https://docs.couchbase.com/sdk-api/couchbase-ruby-client/Couchbase/Management/BucketSettings.html[API docs^] for a full list of settings options.
 
@@ -61,7 +61,7 @@ As well as flushing the bucket.
 
 == Flushing Buckets
 
-include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
+include::{version-common}@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
 
 You can flush a bucket in the SDK by using the `flush_bucket()` method.
 
@@ -149,7 +149,7 @@ For those occasions when you do, please see the relevant API docs, linked xref:#
 
 == View Management
 
-include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
+include::{version-common}@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
 
 In the SDK, design documents are represented by the `DesignDocument` and `View` classes.
 All operations on design documents are performed on the `ViewIndexManager` instance:

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -23,9 +23,9 @@ include::hello-world:example$start_using.rb[tag=connect,indent=0]
 ----
 
 
-include::{version-server}@sdk:shared:partial$auth-overview.adoc[tag=rbac]
+include::{version-common}@sdk:shared:partial$auth-overview.adoc[tag=rbac]
 
-include::{version-server}@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
+include::{version-common}@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
 
 
 == Authenticating a Ruby Client by Certificate
@@ -42,7 +42,7 @@ include::example$auth.rb[tag=auth2,indent=0]
 ----
 
 
-include::{version-server}@sdk:shared:partial$auth-overview.adoc[tag=ldap]
+include::{version-common}@sdk:shared:partial$auth-overview.adoc[tag=ldap]
 
 [source,ruby]
 ----

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -421,7 +421,7 @@ NOTE: Currently, paths cannot exceed 1024 characters, and cannot be more than 32
 
 
 // xattrs
-include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=extended_attributes]
+include::{version-common}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=extended_attributes]
 
 
 == XDCR

--- a/modules/howtos/pages/view-queries-with-sdk.adoc
+++ b/modules/howtos/pages/view-queries-with-sdk.adoc
@@ -9,13 +9,13 @@ include::project-docs:partial$attributes.adoc[]
 {description}
 
 
-// include::{version-server}@sdk:shared:partial$views.adoc[tag=deprecate]
-include::{version-server}@sdk:shared:partial$views.adoc[tag=deprecate]
+// include::{version-common}@sdk:shared:partial$views.adoc[tag=deprecate]
+include::{version-common}@sdk:shared:partial$views.adoc[tag=deprecate]
 
  
-include::{version-server}@sdk:shared:partial$views.adoc[tag=views-intro]
+include::{version-common}@sdk:shared:partial$views.adoc[tag=views-intro]
 
-// include::{version-server}@sdk:shared:partial$views.adoc[tag=example-beer]
+// include::{version-common}@sdk:shared:partial$views.adoc[tag=example-beer]
 
 == Querying Views
 

--- a/modules/howtos/pages/working-with-collections.adoc
+++ b/modules/howtos/pages/working-with-collections.adoc
@@ -1,3 +1,3 @@
 include::project-docs:partial$attributes.adoc[]
 
-include::{version-server}@sdk:shared:partial$working-with-collections.adoc[]
+include::{version-common}@sdk:shared:partial$working-with-collections.adoc[]

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -4,6 +4,8 @@ Plus notes on Cloud, networks, and AWS Lambda.
 :page-aliases: ROOT:overview,ROOT:compatibility-versions-features,compatibility-versions-features
 :page-toclevels: 2
 
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 {description}
 
@@ -52,7 +54,7 @@ See the notes there for Support details.
 At time of release, the Couchbase 3.3 Ruby SDK is fully compatible with Couchbase Capella, our fully-hosted database-as-a-service.
 To make development easier, the 3.3 SDK includes the Capella client certificate ready installed.
 
-include::7.1@sdk:shared:partial$capella.adoc[tag=cloud]
+include::{version-common}@sdk:shared:partial$capella.adoc[tag=cloud]
 
 
 == Couchbase New Feature Availability Matrix
@@ -87,11 +89,11 @@ include::7.1@sdk:shared:partial$capella.adoc[tag=cloud]
 2+| Since SDK 3.2.0
 |===
 
-include::7.1@sdk:shared:partial$network-requirements.adoc[]
+include::{version-common}@sdk:shared:partial$network-requirements.adoc[]
 
 
-include::7.1@sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]
+include::{version-common}@sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]
 
-include::7.1@sdk:shared:partial$api-version.adoc[tag=api-version]
+include::{version-common}@sdk:shared:partial$api-version.adoc[tag=api-version]
 
-include::7.1@sdk:shared:partial$archive.adoc[tag=link]
+include::{version-common}@sdk:shared:partial$archive.adoc[tag=link]

--- a/modules/project-docs/pages/get-involved.adoc
+++ b/modules/project-docs/pages/get-involved.adoc
@@ -8,4 +8,4 @@ Couchbase welcomes community contributions to the Ruby SDK.
 The https://github.com/couchbase/couchbase-ruby-client[Ruby SDK source code^] is available on GitHub.
 Please see the https://github.com/couchbase/couchbase-ruby-client/blob/master/CONTRIBUTING.md[CONTRIBUTING^] file for further information.
 
-include::{version-server}@sdk:shared:partial$contrib.adoc[tag=contrib]
+include::{version-common}@sdk:shared:partial$contrib.adoc[tag=contrib]

--- a/modules/project-docs/pages/third-party-integrations.adoc
+++ b/modules/project-docs/pages/third-party-integrations.adoc
@@ -10,10 +10,10 @@ include::project-docs:partial$attributes.adoc[]
 {description}
 
 
-include::{version-server}@sdk:shared:partial$integrations.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$integrations.adoc[tag=intro]
 
 
-include::{version-server}@sdk:shared:partial$integrations.adoc[tag=important]
+include::{version-common}@sdk:shared:partial$integrations.adoc[tag=important]
 
 The Couchbase Ruby SDK integrates well with Ruby-on-Rails, particularly for use as a https://guides.rubyonrails.org/caching_with_rails.html#cache-stores[Rails Cache Store^].
 To do so, add the following to your Rails application config:

--- a/modules/project-docs/partials/attributes.adoc
+++ b/modules/project-docs/partials/attributes.adoc
@@ -2,3 +2,4 @@
 :ruby-current-version: 3.3.0
 :name-sdk: Ruby SDK
 :version-server: 7.1
+:version-common: 7.1.2

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -164,4 +164,4 @@ This means that tuning the number of connections (KV endpoints) is no longer nec
 This is set to true by default. Note, changing the setting will only affect Server versions 7.0 onwards.
 
 
-include::{version-server}@sdk:shared:partial$client-settings-wide-network.adoc[]
+include::{version-common}@sdk:shared:partial$client-settings-wide-network.adoc[]

--- a/modules/ref/pages/error-codes.adoc
+++ b/modules/ref/pages/error-codes.adoc
@@ -7,39 +7,39 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=intro]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=intro]
 
 == Shared Error Definitions 
 
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=shared]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=shared]
 
 
 == KeyValue Error Definitions
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=kv]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=kv]
 
 
 == Query Error Definitions
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=query]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=query]
 
 
 == Analytics Error Definitions
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=analytics]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=analytics]
 
 
 == Search Error Definition
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=search]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=search]
 
 
 == View Error Definitions
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=views]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=views]
 
 
 == Management API Error Definitions
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=mgmnt]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=mgmnt]
 
 
 == Field-Level Encryption Error Definitions
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=fle]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=fle]
 
 
 ////
@@ -53,7 +53,7 @@ This range is reserved for sdk-specific error codes which are not standardized, 
 
 
 == Connecting to Cloud
-include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=cloud]
+include::{version-common}@sdk:shared:partial$error-ref.adoc[tag=cloud]
 
 
 == Further Reading


### PR DESCRIPTION
I've added an attributed called `version-common` to allow us to set the version for sdk-common, which gives us more flexibility in cases where the server version and common version have diverged a little.
