### PR TITLE
DOC-10496: Update Root CA section

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -139,13 +139,15 @@ The Ruby SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] 
 
 IMPORTANT: {cbpp} loads OpenSSL's root CA store, therefore you should make sure that your system or platform is configured to support this.
 
-Depending on your OpenSSL installation, OpenSSL might not contain any certificates in its CA store by default, which you might wish to populate. You can find the location of the OpenSSL executable used by Ruby by running:
+Depending on your OpenSSL installation, OpenSSL might not contain any certificates in its CA store by default, which you might wish to populate.
+You can find the location of the OpenSSL executable used by Ruby with the following command:
 
+[source,console]
 ----
 ruby -r rbconfig -e 'puts RbConfig::CONFIG["configure_args"]'
 ----
 
-Then, you can get find the directory where the certificates OpenSSL trusts are stored by running `./openssl version -d` where `openssl` is the relevant OpenSSL executable.
+You can get the directory where the certificate's OpenSSL trusts are stored by running `./openssl version -d` -- where `openssl` is the relevant OpenSSL executable.
 
 You can still provide a certificate explicitly if necessary:
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -147,7 +147,7 @@ You can find the location of the OpenSSL executable used by Ruby with the follow
 ruby -r rbconfig -e 'puts RbConfig::CONFIG["configure_args"]'
 ----
 
-You can get the directory where the certificate's OpenSSL trusts are stored by running `./openssl version -d` -- where `openssl` is the relevant OpenSSL executable.
+To locate the directory where OpenSSL stores trusted certificates, you can run `./openssl version -d` -- where `openssl` is the relevant OpenSSL executable.
 
 You can still provide a certificate explicitly if necessary:
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -133,12 +133,19 @@ Couchbase Server::
 --
 As of SDK 3.4, if you connect to a Couchbase Server cluster with a root certificate issued by a trusted CA (Certificate Authority), you no longer need to configure the `trust_certificate` path in your connection string.
 
-The cluster's root certificate just needs to be issued by a CA whose certificate is in your system trust store.
-This includes publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
-The Ruby SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the platform root CA.
+The cluster's root certificate just needs to be issued by a CA whose certificate is in your OpenSSL trust store.
+This can include publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
+The Ruby SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the root CAs.
 
-IMPORTANT: {cbpp} loads your platform's root CA store in a similar way to the Ruby OpenSSL wrapper.
-If your system does not have a default root CA store, it will use the Mozilla CA certificate store.
+IMPORTANT: {cbpp} loads OpenSSL's root CA store, therefore you should make sure that your system or platform is configured to support this.
+
+Depending on your OpenSSL installation, OpenSSL might not contain any certificates in its CA store by default, which you might wish to populate. You can find the location of the OpenSSL executable used by Ruby by running:
+
+----
+ruby -r rbconfig -e 'puts RbConfig::CONFIG["configure_args"]'
+----
+
+Then, you can get find the directory where the certificates OpenSSL trusts are stored by running `./openssl version -d` where `openssl` is the relevant OpenSSL executable.
 
 You can still provide a certificate explicitly if necessary:
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -137,8 +137,7 @@ The cluster's root certificate just needs to be issued by a CA whose certificate
 This includes publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
 The Ruby SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the platform root CA.
 
-IMPORTANT: {cbpp} loads your platform's root CA store in a similar way to the Ruby OpenSSL wrapper.
-If your system does not have a default root CA store, it will use the Mozilla CA certificate store.
+IMPORTANT: {cbpp} loads your platform’s root CA store using OpenSSL, therefore you should make sure that your system or platform is configured to support this.
 
 You can still provide a certificate explicitly if necessary:
 


### PR DESCRIPTION
I've made some changes to the root CA section:
* Changed the reference to "system trust store" to "OpenSSL trust store" - We retrieve the root CAs from the OpenSSL store, which is separate from the system one.
* Removed the reference to using the Mozilla cert store if the system one does not exist (I don't think we have implemented this)
* Added information on locating the OpenSSL executable Ruby is using (It's common to have more than 1 installations of OpenSSL)
* Added information on finding the directory where OpenSSL stores the certificates it trusts, because this could be empty depending on how OpenSSL was installed (e.g. Installing openssl via homebrew on macOS populates the cert store, but generally OpenSSL does not bundle certificates by default).