### PR TITLE
release notes for 3.4.0

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -9,12 +9,12 @@
 [abstract]
 {description}
 
-This page covers installation of the 3.3 versions of the Couchbase Ruby SDK, and release notes for all 3.x versions.
+This page covers installation of the 3.4 versions of the Couchbase Ruby SDK, and release notes for all 3.x versions.
 
 
 == SDK Installation
 
-Ruby SDK supports MRI Ruby versions 2.7, 3.0 and 3.1.
+Ruby SDK supports MRI Ruby versions 3.0, 3.1 and 3.2.
 The source package is available through https://rubygems.org/gems/couchbase and can be installed with
 
 [source,console]
@@ -31,28 +31,33 @@ package, but also precompiled binaries for Linux and MacOS.
 [cols="4,17"]
 |===
 | Ruby ABI version | Source URL
-| 3.1   | https://packages.couchbase.com/clients/ruby/3.1.0/
-| 3.0   | https://packages.couchbase.com/clients/ruby/3.0.0/
-| 2.7   | https://packages.couchbase.com/clients/ruby/2.7.0/
+| 3.2              | https://packages.couchbase.com/clients/ruby/3.2.0/
+| 3.1              | https://packages.couchbase.com/clients/ruby/3.1.0/
+| 3.0              | https://packages.couchbase.com/clients/ruby/3.0.0/
 |===
 
 To use official repository, it have to be registered in the `.gemrc` file:
 
-The example above selects repository with the packages for Ruby 2.7.x. For other version, please refer the table.
+[source,bash]
+----
+gem sources --add https://packages.couchbase.com/clients/ruby/3.1.0/
+----
+
+The example above selects repository with the packages for Ruby 3.1.x. For other version, please refer the table.
 
 The repository could be also specified in `Gemfile` for bundler. And in this case the source would be applied only for
 Couchbase SDK library:
 
 [source,ruby]
 ----
-gem "couchbase", "3.3.0", :source => "https://packages.couchbase.com/clients/ruby/2.7.0/"
+gem "couchbase", "3.4.0", :source => "https://packages.couchbase.com/clients/ruby/3.1.0/"
 ----
 
 Or run in terminal:
 
 [source,bash]
 ----
-gem install couchbase --clear-sources --source https://packages.couchbase.com/clients/ruby/2.7.0/
+gem install couchbase --clear-sources --source https://packages.couchbase.com/clients/ruby/3.1.0/
 ----
 
 And finally, it is possible to download the package and install from the file. In the notes below, we specify tables
@@ -60,12 +65,153 @@ with links to every release package along with precompiled binaries.
 
 [source,bash]
 ----
-wget https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-linux-2.7.0.gem
-gem install couchbase-3.3.0-x86_64-linux-2.7.0.gem
+wget https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-3.1.0.gem
+gem install couchbase-3.4.0-x86_64-linux-3.1.0.gem
 ----
+
+The URL structure is:
+
+[source]
+---
+https://packages.couchbase.com/clients/ruby/sdk-%{sdk_version}/couchbase-%{sdk_version}-%{platform}-%{ruby_abi}.gem
+---
+
+where "platform" placeholder can take values: `arm64-darwin-20`, `x86_64-darwin-19`, `x86_64-darwin-20`, `x86_64-linux`,
+* `x86_64-linux-musl`. To see platform string the following command:
+
+[source,bash]
+---
+ruby -rrbconfig -e 'puts RbConfig::CONFIG["platform"]'
+---
+
+and "ruby_abi" placeholder represent Ruby ABI version, as it is reported in
+
+[source,bash]
+---
+ruby -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]'
+---
 
 
 [#latest-release]
+== Version 3.4.0 (19 February 2022)
+
+https://docs.couchbase.com/sdk-api/couchbase-ruby-client-3.4.0/index.html[API Reference]
+
+Improvements:
+* https://issues.couchbase.com/browse/RCBC-378: Implement change password for `Management::User` class. (#65)
+* https://issues.couchbase.com/browse/RCBC-388: Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (#55)
+* https://issues.couchbase.com/browse/RCBC-263: Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (#49)
+* https://issues.couchbase.com/browse/RCBC-387: Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (#48)
+* https://issues.couchbase.com/browse/RCBC-375: Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (#45)
+* https://issues.couchbase.com/browse/RCBC-371: Return id for `*_multi` results. (#40)
+* https://issues.couchbase.com/browse/RCBC-393: Fix type conversion for query metrics. (#62)
+* https://issues.couchbase.com/browse/RCBC-398: Add `ClusterRegistry` to allow custom connection string handlers. (#68)
+* https://issues.couchbase.com/browse/RCBC-366: Allow to override default timeouts through `Options::Cluster` (#37)
+* https://issues.couchbase.com/browse/RCBC-399: Add default options objects as class constants. (#69)
+
+Notable changes in C++ SDK 1.0.0-beta.5:
+
+* https://issues.couchbase.com/browse/CXXCBC-275[CXXCBC-275]: Update implementation query context fields passed to the server. In future versions of the server versions it will become mandatory to specify context of the statement (bucket, scope and collection). This change ensures that both future and current server releases supported transparently.
+
+* https://issues.couchbase.com/browse/CXXCBC-296[CXXCBC-296]: Force PLAIN SASL auth if TLS enabled. Using SCRAM SASL mechanisms over TLS protocol is unnecesary complication, that slows down initial connection bootstrap and potentially limits server ability to improve security and evolve credentials management.
+
+* https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-295]: The `get with projections` opration should not fail if one of the the paths is missing in the document, because the semantics is "get the partial document" and not "get individual fields" like in `lookup_in` operation.
+
+* https://issues.couchbase.com/browse/CXXCBC-294[CXXCBC-294]: In the Public API, if `get` operation requested to return expiry time, zero expiry should not be interpreted as absolute expiry timestamp (zero seconds from UNIX epoch), but rather as absense of the expiry.
+
+* https://issues.couchbase.com/browse/CXXCBC-291[CXXCBC-291]: Allow to disable mutation tokens for Key/Value mutations (use `enable_mutation_tokens` in connection string).
+
+* Resource management and performance improvements:
+    * Fix tracer and meter ref-counting (#370)
+    * Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (#356)
+    * https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: Write to sockets from IO threads, to eliminate potential race conditions. (#348)
+    * Eliminate looping transform in `mcbp_parser::next` (#347)
+    * https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: Use thread-local UUID generator (#340)
+    * https://issues.couchbase.com/browse/CXXCBC-293[CXXCBC-293]: Performance improvements:
+        * Speed up UUID serialization to string (#346)
+        * Don't allow to copy `mcbp_message` objects (#345)
+        * Avoid extra allocation and initialization (#344)
+
+* Build system fixes:
+    * Fix build with gcc-13 (#372)
+    * Fix gcc 12 issue (#367)
+
+* Enhancements:
+    * Include bucketless KV service when ping is requested. (#339)
+    * Include OS name in SDK identifier (#349)
+
+Notable changes in C++ SDK 1.0.0-beta.4
+
+* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (#336)
+
+
+Notable changes in C++ SDK 1.0.0-dp.2
+
+* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: Drain waiting commands list on MCBP session close (#321)
+* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (#322)
+
+Notable changes in C++ SDK 1.0.0-dp.1
+
+* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: Update SRV resolution for Windows (#303)
+* https://issues.couchbase.com/browse/CXXCBC-172[CXXCBC-172]: Refresh DNS SRV when cluster uncontactable (#275, #290)
+* https://issues.couchbase.com/browse/CXXCBC-234[CXXCBC-234]: Error message for bucket hibernation and update error message for authentication_failure. (#280, #285)
+* https://issues.couchbase.com/browse/CXXCBC-235[CXXCBC-235]: Load system CAs when the trust certificate is not provided and do not fail if trust certificate is not specified (#283, #281)
+* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: Fix encoding of durability frame (#277)
+* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: Convert `not_stored` code to `document_exists` (#278)
+* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: Fix snappy decompression for `get_replica` (#296)
+* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: `query_options` not setting `scope_qualifier` (#300)
+* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: Fix failures in serverless mode (#274)
+* Don't log expected warnings in DNS resolver (#294)
+
+Resource management and performance fixes:
+* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: don't throw exceptions when socket options cannot be set (#270)
+
+Build system fixes:
+* Move away from `reinterpret_pointer_cast<>` for MacOS build issue (#288)
+* Improve OpenSSL detection on Windows (#272)
+
+Notable changes in C++ SDK 1.0.0-beta.3
+
+* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: Support for configuration profiles (#268)
+* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: allow to check if subdoc result field has value (#263)
+* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: Always set `kv_collection_outdated` retry reason on unknown collection error (#223)
+* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: disable clustermap nofication by default (#233)
+* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: Increment/decrement should not have `preserve_expiry` (#201)
+* https://issues.couchbase.com/browse/CXXCBC-55[CXXCBC-55]: External Tracing and Metrics support with OpenTelemetry support (#228, #231)
+* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: Add log forwarding (#206)
+
+Bug fixes:
+* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: Close http_session before conecting to next endpoint (#213)
+* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: fix parsing responses with chunked meta trailer (#191)
+* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: add extra check for missing CA for TLS connections (#197)
+* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: add extra check for keywords in query index fields (#196)
+* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: complete streaming lexer even if pointer didn't match (#195)
+* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: reprepare and retry query on 4040, 4050 and 4070 (#257)
+* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: reduce scope of the http request lock (#259)
+* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: ignore 'is_primary' for named primary indexes when dropping (#202)
+* return subdocument error context from future-based subdoc methods (#258)
+
+
+[cols="9,5,19"]
+|===
+| Platform            | Ruby ABI | File
+| Checksums           |          | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0.sha256sum[couchbase-3.4.0.sha256sum]
+| Source Archive      |          | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0.gem[couchbase-3.4.0.gem]
+| Linux x86_64        | 3.2.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-3.2.0.gem[couchbase-3.4.0-x86_64-linux-3.2.0.gem]
+| Linux x86_64        | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-3.1.0.gem[couchbase-3.4.0-x86_64-linux-3.1.0.gem]
+| Linux x86_64        | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-3.0.0.gem[couchbase-3.4.0-x86_64-linux-3.0.0.gem]
+| Linux x86_64 (musl) | 3.2.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-musl-3.2.0.gem[couchbase-3.4.0-x86_64-linux-musl-3.2.0.gem]
+| Linux x86_64 (musl) | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-musl-3.1.0.gem[couchbase-3.4.0-x86_64-linux-musl-3.1.0.gem]
+| Linux x86_64 (musl) | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-linux-musl-3.0.0.gem[couchbase-3.4.0-x86_64-linux-musl-3.0.0.gem]
+| macOS 10.15 x84_64  | 3.2.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-darwin-19-3.2.0.gem[couchbase-3.4.0-x86_64-darwin-19-3.2.0.gem]
+| macOS 10.15 x84_64  | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-darwin-19-3.0.0.gem[couchbase-3.4.0-x86_64-darwin-19-3.0.0.gem]
+| macOS 11 x84_64     | 3.2.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-darwin-20-3.2.0.gem[couchbase-3.4.0-x86_64-darwin-20-3.2.0.gem]
+| macOS 11 x84_64     | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-darwin-20-3.1.0.gem[couchbase-3.4.0-x86_64-darwin-20-3.1.0.gem]
+| macOS 11 x84_64     | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-x86_64-darwin-20-3.0.0.gem[couchbase-3.4.0-x86_64-darwin-20-3.0.0.gem]
+| macOS 11 M1         | 3.2.0    | https://packages.couchbase.com/clients/ruby/sdk-3.4.0/couchbase-3.4.0-arm64-darwin-20-3.0.0.gem[couchbase-3.4.0-arm64-darwin-20-3.0.0.gem]
+|===
+
+
 == Version 3.3.0 (5 May 2022)
 
 This is the first GA release of the 3.3 series.
@@ -75,11 +221,11 @@ https://docs.couchbase.com/sdk-api/couchbase-ruby-client-3.3.0/index.html[API Re
 Improvements:
 
 * https://issues.couchbase.com/browse/RCBC-338[RCBC-338]:
-  Added new options for the search API. 
+  Added new options for the search API.
   You can now add the `operator` and `include_locations` properties to all search queries.
 
 * https://issues.couchbase.com/browse/RCBC-358[RCBC-358], https://issues.couchbase.com/browse/RCBC-346[RCBC-346]:
-  Added new options for the bucket API. 
+  Added new options for the bucket API.
   The SDK now allows you to configure the custom conflict resolution storage backend for new buckets.
 
 * https://issues.couchbase.com/browse/RCBC-345[RCBC-345]:
@@ -101,17 +247,17 @@ Fixes:
 [cols="9,5,19"]
 |===
 | Platform           | Ruby ABI | File
-| Checksums          |          | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0.sha256sum[couchbase-3.2.0.sha256sum]
-| Source Archive     |          | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0.gem[couchbase-3.2.0.gem]
-| Linux x86_64       | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-linux-3.1.0.gem[couchbase-3.2.0-x86_64-linux-3.1.0.gem]
-| Linux x86_64       | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-linux-3.0.0.gem[couchbase-3.2.0-x86_64-linux-3.0.0.gem]
-| Linux x86_64       | 2.7.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-linux-2.7.0.gem[couchbase-3.2.0-x86_64-linux-2.7.0.gem]
-| macOS 10.15 x84_64 | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-darwin-19-3.1.0.gem[couchbase-3.2.0-x86_64-darwin-19-3.1.0.gem]
-| macOS 10.15 x84_64 | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-darwin-19-3.0.0.gem[couchbase-3.2.0-x86_64-darwin-19-3.0.0.gem]
-| macOS 10.15 x84_64 | 2.7.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-darwin-19-2.7.0.gem[couchbase-3.2.0-x86_64-darwin-19-2.7.0.gem]
-| macOS 11 x84_64 | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-darwin-20-3.1.0.gem[couchbase-3.2.0-x86_64-darwin-20-3.1.0.gem]
-| macOS 11 x84_64 | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-darwin-20-3.0.0.gem[couchbase-3.2.0-x86_64-darwin-20-3.0.0.gem]
-| macOS 11 x84_64 | 2.7.0    | https://packages.couchbase.com/clients/ruby/sdk-3.2.0/couchbase-3.2.0-x86_64-darwin-20-2.7.0.gem[couchbase-3.2.0-x86_64-darwin-20-2.7.0.gem]
+| Checksums          |          | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0.sha256sum[couchbase-3.3.0.sha256sum]
+| Source Archive     |          | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0.gem[couchbase-3.3.0.gem]
+| Linux x86_64       | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-linux-3.1.0.gem[couchbase-3.3.0-x86_64-linux-3.1.0.gem]
+| Linux x86_64       | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-linux-3.0.0.gem[couchbase-3.3.0-x86_64-linux-3.0.0.gem]
+| Linux x86_64       | 2.7.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-linux-2.7.0.gem[couchbase-3.3.0-x86_64-linux-2.7.0.gem]
+| macOS 10.15 x84_64 | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-darwin-19-3.1.0.gem[couchbase-3.3.0-x86_64-darwin-19-3.1.0.gem]
+| macOS 10.15 x84_64 | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-darwin-19-3.0.0.gem[couchbase-3.3.0-x86_64-darwin-19-3.0.0.gem]
+| macOS 10.15 x84_64 | 2.7.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-darwin-19-2.7.0.gem[couchbase-3.3.0-x86_64-darwin-19-2.7.0.gem]
+| macOS 11 x84_64 | 3.1.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-darwin-20-3.1.0.gem[couchbase-3.3.0-x86_64-darwin-20-3.1.0.gem]
+| macOS 11 x84_64 | 3.0.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-darwin-20-3.0.0.gem[couchbase-3.3.0-x86_64-darwin-20-3.0.0.gem]
+| macOS 11 x84_64 | 2.7.0    | https://packages.couchbase.com/clients/ruby/sdk-3.3.0/couchbase-3.3.0-x86_64-darwin-20-2.7.0.gem[couchbase-3.3.0-x86_64-darwin-20-2.7.0.gem]
 |===
 
 == Version 3.2.0 (4 August 2021)
@@ -121,7 +267,7 @@ This is the first GA release of the 3.2 series.
 https://docs.couchbase.com/sdk-api/couchbase-ruby-client-3.2.0/index.html[API Reference]
 
 * https://issues.couchbase.com/browse/RCBC-301[RCBC-301]:
-  Implemented metrics. 
+  Implemented metrics.
   This feature is enabled by default; it can be disabled in the connection string with `enable_metrics=false`, or programmatically:
 +
 [source,ruby]
@@ -139,7 +285,7 @@ options.metrics_emit_interval = 60_000 # in milliseconds, default 10 minutes
 ----
 
 * https://issues.couchbase.com/browse/RCBC-234[RCBC-234]:
- Implemented tracing. 
+ Implemented tracing.
  This feature is enabled by default; it can be disabled in the connection string with `enable_tracing=false`, or programmatically:
 +
 [source,ruby]

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -98,16 +98,16 @@ ruby -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]'
 https://docs.couchbase.com/sdk-api/couchbase-ruby-client-3.4.0/index.html[API Reference]
 
 Improvements:
-* https://issues.couchbase.com/browse/RCBC-378: Implement change password for `Management::User` class. (#65)
-* https://issues.couchbase.com/browse/RCBC-388: Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (#55)
-* https://issues.couchbase.com/browse/RCBC-263: Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (#49)
-* https://issues.couchbase.com/browse/RCBC-387: Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (#48)
-* https://issues.couchbase.com/browse/RCBC-375: Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (#45)
-* https://issues.couchbase.com/browse/RCBC-371: Return id for `*_multi` results. (#40)
-* https://issues.couchbase.com/browse/RCBC-393: Fix type conversion for query metrics. (#62)
-* https://issues.couchbase.com/browse/RCBC-398: Add `ClusterRegistry` to allow custom connection string handlers. (#68)
-* https://issues.couchbase.com/browse/RCBC-366: Allow to override default timeouts through `Options::Cluster` (#37)
-* https://issues.couchbase.com/browse/RCBC-399: Add default options objects as class constants. (#69)
+* https://issues.couchbase.com/browse/RCBC-378[RCBC-378]: Implement change password for `Management::User` class. (https://github.com/couchbase/docs-sdk-ruby/pull/65[#65])
+* https://issues.couchbase.com/browse/RCBC-388[RCBC-388]: Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (https://github.com/couchbase/docs-sdk-ruby/pull/55[#55])
+* https://issues.couchbase.com/browse/RCBC-263[RCBC-263]: Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (https://github.com/couchbase/docs-sdk-ruby/pull/49[#49])
+* https://issues.couchbase.com/browse/RCBC-387[RCBC-387]: Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (https://github.com/couchbase/docs-sdk-ruby/pull/48[#48])
+* https://issues.couchbase.com/browse/RCBC-375[RCBC-375]: Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (https://github.com/couchbase/docs-sdk-ruby/pull/45[#45])
+* https://issues.couchbase.com/browse/RCBC-371[RCBC-371]: Return id for `*_multi` results. (https://github.com/couchbase/docs-sdk-ruby/pull/40[#40])
+* https://issues.couchbase.com/browse/RCBC-393[RCBC-393]: Fix type conversion for query metrics. (https://github.com/couchbase/docs-sdk-ruby/pull/62[#62])
+* https://issues.couchbase.com/browse/RCBC-398[RCBC-398]: Add `ClusterRegistry` to allow custom connection string handlers. (https://github.com/couchbase/docs-sdk-ruby/pull/68[#68])
+* https://issues.couchbase.com/browse/RCBC-366[RCBC-366]: Allow to override default timeouts through `Options::Cluster` (https://github.com/couchbase/docs-sdk-ruby/pull/37[#37])
+* https://issues.couchbase.com/browse/RCBC-399[RCBC-399]: Add default options objects as class constants. (https://github.com/couchbase/docs-sdk-ruby/pull/69[#69])
 
 Notable changes in C++ SDK 1.0.0-beta.5:
 
@@ -122,74 +122,74 @@ Notable changes in C++ SDK 1.0.0-beta.5:
 * https://issues.couchbase.com/browse/CXXCBC-291[CXXCBC-291]: Allow to disable mutation tokens for Key/Value mutations (use `enable_mutation_tokens` in connection string).
 
 * Resource management and performance improvements:
-    * Fix tracer and meter ref-counting (#370)
-    * Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (#356)
-    * https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: Write to sockets from IO threads, to eliminate potential race conditions. (#348)
-    * Eliminate looping transform in `mcbp_parser::next` (#347)
-    * https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: Use thread-local UUID generator (#340)
+    * Fix tracer and meter ref-counting (https://github.com/couchbase/docs-sdk-ruby/pull/370[#370])
+    * Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (https://github.com/couchbase/docs-sdk-ruby/pull/356[#356])
+    * https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: Write to sockets from IO threads, to eliminate potential race conditions. (https://github.com/couchbase/docs-sdk-ruby/pull/348[#348])
+    * Eliminate looping transform in `mcbp_parser::next` (https://github.com/couchbase/docs-sdk-ruby/pull/347[#347])
+    * https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: Use thread-local UUID generator (https://github.com/couchbase/docs-sdk-ruby/pull/340[#340])
     * https://issues.couchbase.com/browse/CXXCBC-293[CXXCBC-293]: Performance improvements:
-        * Speed up UUID serialization to string (#346)
-        * Don't allow to copy `mcbp_message` objects (#345)
-        * Avoid extra allocation and initialization (#344)
+        * Speed up UUID serialization to string (https://github.com/couchbase/docs-sdk-ruby/pull/346[#346])
+        * Don't allow to copy `mcbp_message` objects (https://github.com/couchbase/docs-sdk-ruby/pull/345[#345])
+        * Avoid extra allocation and initialization (https://github.com/couchbase/docs-sdk-ruby/pull/344[#344])
 
 * Build system fixes:
-    * Fix build with gcc-13 (#372)
-    * Fix gcc 12 issue (#367)
+    * Fix build with gcc-13 (https://github.com/couchbase/docs-sdk-ruby/pull/372[#372])
+    * Fix gcc 12 issue (https://github.com/couchbase/docs-sdk-ruby/pull/367[#367])
 
 * Enhancements:
-    * Include bucketless KV service when ping is requested. (#339)
-    * Include OS name in SDK identifier (#349)
+    * Include bucketless KV service when ping is requested. (https://github.com/couchbase/docs-sdk-ruby/pull/339[#339])
+    * Include OS name in SDK identifier (https://github.com/couchbase/docs-sdk-ruby/pull/349[#349])
 
 Notable changes in C++ SDK 1.0.0-beta.4
 
-* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (#336)
+* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (https://github.com/couchbase/docs-sdk-ruby/pull/336[#336])
 
 
 Notable changes in C++ SDK 1.0.0-dp.2
 
-* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: Drain waiting commands list on MCBP session close (#321)
-* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (#322)
+* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: Drain waiting commands list on MCBP session close (https://github.com/couchbase/docs-sdk-ruby/pull/321[#321])
+* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (https://github.com/couchbase/docs-sdk-ruby/pull/322[#322])
 
 Notable changes in C++ SDK 1.0.0-dp.1
 
-* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: Update SRV resolution for Windows (#303)
+* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: Update SRV resolution for Windows (https://github.com/couchbase/docs-sdk-ruby/pull/303[#303])
 * https://issues.couchbase.com/browse/CXXCBC-172[CXXCBC-172]: Refresh DNS SRV when cluster uncontactable (#275, #290)
 * https://issues.couchbase.com/browse/CXXCBC-234[CXXCBC-234]: Error message for bucket hibernation and update error message for authentication_failure. (#280, #285)
 * https://issues.couchbase.com/browse/CXXCBC-235[CXXCBC-235]: Load system CAs when the trust certificate is not provided and do not fail if trust certificate is not specified (#283, #281)
-* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: Fix encoding of durability frame (#277)
-* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: Convert `not_stored` code to `document_exists` (#278)
-* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: Fix snappy decompression for `get_replica` (#296)
-* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: `query_options` not setting `scope_qualifier` (#300)
-* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: Fix failures in serverless mode (#274)
-* Don't log expected warnings in DNS resolver (#294)
+* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: Fix encoding of durability frame (https://github.com/couchbase/docs-sdk-ruby/pull/277[#277])
+* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: Convert `not_stored` code to `document_exists` (https://github.com/couchbase/docs-sdk-ruby/pull/278[#278])
+* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: Fix snappy decompression for `get_replica` (https://github.com/couchbase/docs-sdk-ruby/pull/296[#296])
+* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: `query_options` not setting `scope_qualifier` (https://github.com/couchbase/docs-sdk-ruby/pull/300[#300])
+* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: Fix failures in serverless mode (https://github.com/couchbase/docs-sdk-ruby/pull/274[#274])
+* Don't log expected warnings in DNS resolver (https://github.com/couchbase/docs-sdk-ruby/pull/294[#294])
 
 Resource management and performance fixes:
-* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: don't throw exceptions when socket options cannot be set (#270)
+* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: don't throw exceptions when socket options cannot be set (https://github.com/couchbase/docs-sdk-ruby/pull/270[#270])
 
 Build system fixes:
-* Move away from `reinterpret_pointer_cast<>` for MacOS build issue (#288)
-* Improve OpenSSL detection on Windows (#272)
+* Move away from `reinterpret_pointer_cast<>` for MacOS build issue (https://github.com/couchbase/docs-sdk-ruby/pull/288[#288])
+* Improve OpenSSL detection on Windows (https://github.com/couchbase/docs-sdk-ruby/pull/272[#272])
 
 Notable changes in C++ SDK 1.0.0-beta.3
 
-* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: Support for configuration profiles (#268)
-* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: allow to check if subdoc result field has value (#263)
-* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: Always set `kv_collection_outdated` retry reason on unknown collection error (#223)
-* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: disable clustermap nofication by default (#233)
-* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: Increment/decrement should not have `preserve_expiry` (#201)
+* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: Support for configuration profiles (https://github.com/couchbase/docs-sdk-ruby/pull/268[#268])
+* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: allow to check if subdoc result field has value (https://github.com/couchbase/docs-sdk-ruby/pull/263[#263])
+* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: Always set `kv_collection_outdated` retry reason on unknown collection error (https://github.com/couchbase/docs-sdk-ruby/pull/223[#223])
+* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: disable clustermap nofication by default (https://github.com/couchbase/docs-sdk-ruby/pull/233[#233])
+* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: Increment/decrement should not have `preserve_expiry` (https://github.com/couchbase/docs-sdk-ruby/pull/201[#201])
 * https://issues.couchbase.com/browse/CXXCBC-55[CXXCBC-55]: External Tracing and Metrics support with OpenTelemetry support (#228, #231)
-* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: Add log forwarding (#206)
+* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: Add log forwarding (https://github.com/couchbase/docs-sdk-ruby/pull/206[#206])
 
 Bug fixes:
-* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: Close http_session before conecting to next endpoint (#213)
-* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: fix parsing responses with chunked meta trailer (#191)
-* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: add extra check for missing CA for TLS connections (#197)
-* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: add extra check for keywords in query index fields (#196)
-* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: complete streaming lexer even if pointer didn't match (#195)
-* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: reprepare and retry query on 4040, 4050 and 4070 (#257)
-* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: reduce scope of the http request lock (#259)
-* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: ignore 'is_primary' for named primary indexes when dropping (#202)
-* return subdocument error context from future-based subdoc methods (#258)
+* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: Close http_session before conecting to next endpoint (https://github.com/couchbase/docs-sdk-ruby/pull/213[#213])
+* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: fix parsing responses with chunked meta trailer (https://github.com/couchbase/docs-sdk-ruby/pull/191[#191])
+* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: add extra check for missing CA for TLS connections (https://github.com/couchbase/docs-sdk-ruby/pull/197[#197])
+* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: add extra check for keywords in query index fields (https://github.com/couchbase/docs-sdk-ruby/pull/196[#196])
+* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: complete streaming lexer even if pointer didn't match (https://github.com/couchbase/docs-sdk-ruby/pull/195[#195])
+* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: reprepare and retry query on 4040, 4050 and 4070 (https://github.com/couchbase/docs-sdk-ruby/pull/257[#257])
+* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: reduce scope of the http request lock (https://github.com/couchbase/docs-sdk-ruby/pull/259[#259])
+* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: ignore 'is_primary' for named primary indexes when dropping (https://github.com/couchbase/docs-sdk-ruby/pull/202[#202])
+* return subdocument error context from future-based subdoc methods (https://github.com/couchbase/docs-sdk-ruby/pull/258[#258])
 
 
 [cols="9,5,19"]

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -98,16 +98,16 @@ ruby -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]'
 https://docs.couchbase.com/sdk-api/couchbase-ruby-client-3.4.0/index.html[API Reference]
 
 Improvements:
-* https://issues.couchbase.com/browse/RCBC-378[RCBC-378]: Implement change password for `Management::User` class. (https://github.com/couchbase/docs-sdk-ruby/pull/65[#65])
-* https://issues.couchbase.com/browse/RCBC-388[RCBC-388]: Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (https://github.com/couchbase/docs-sdk-ruby/pull/55[#55])
-* https://issues.couchbase.com/browse/RCBC-263[RCBC-263]: Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (https://github.com/couchbase/docs-sdk-ruby/pull/49[#49])
-* https://issues.couchbase.com/browse/RCBC-387[RCBC-387]: Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (https://github.com/couchbase/docs-sdk-ruby/pull/48[#48])
-* https://issues.couchbase.com/browse/RCBC-375[RCBC-375]: Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (https://github.com/couchbase/docs-sdk-ruby/pull/45[#45])
-* https://issues.couchbase.com/browse/RCBC-371[RCBC-371]: Return id for `*_multi` results. (https://github.com/couchbase/docs-sdk-ruby/pull/40[#40])
-* https://issues.couchbase.com/browse/RCBC-393[RCBC-393]: Fix type conversion for query metrics. (https://github.com/couchbase/docs-sdk-ruby/pull/62[#62])
-* https://issues.couchbase.com/browse/RCBC-398[RCBC-398]: Add `ClusterRegistry` to allow custom connection string handlers. (https://github.com/couchbase/docs-sdk-ruby/pull/68[#68])
-* https://issues.couchbase.com/browse/RCBC-366[RCBC-366]: Allow to override default timeouts through `Options::Cluster` (https://github.com/couchbase/docs-sdk-ruby/pull/37[#37])
-* https://issues.couchbase.com/browse/RCBC-399[RCBC-399]: Add default options objects as class constants. (https://github.com/couchbase/docs-sdk-ruby/pull/69[#69])
+* https://issues.couchbase.com/browse/RCBC-378[RCBC-378]: Implement change password for `Management::User` class. (https://github.com/couchbase/couchbase-ruby-client/pull/65[#65])
+* https://issues.couchbase.com/browse/RCBC-388[RCBC-388]: Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (https://github.com/couchbase/couchbase-ruby-client/pull/55[#55])
+* https://issues.couchbase.com/browse/RCBC-263[RCBC-263]: Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (https://github.com/couchbase/couchbase-ruby-client/pull/49[#49])
+* https://issues.couchbase.com/browse/RCBC-387[RCBC-387]: Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (https://github.com/couchbase/couchbase-ruby-client/pull/48[#48])
+* https://issues.couchbase.com/browse/RCBC-375[RCBC-375]: Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (https://github.com/couchbase/couchbase-ruby-client/pull/45[#45])
+* https://issues.couchbase.com/browse/RCBC-371[RCBC-371]: Return id for `*_multi` results. (https://github.com/couchbase/couchbase-ruby-client/pull/40[#40])
+* https://issues.couchbase.com/browse/RCBC-393[RCBC-393]: Fix type conversion for query metrics. (https://github.com/couchbase/couchbase-ruby-client/pull/62[#62])
+* https://issues.couchbase.com/browse/RCBC-398[RCBC-398]: Add `ClusterRegistry` to allow custom connection string handlers. (https://github.com/couchbase/couchbase-ruby-client/pull/68[#68])
+* https://issues.couchbase.com/browse/RCBC-366[RCBC-366]: Allow to override default timeouts through `Options::Cluster` (https://github.com/couchbase/couchbase-ruby-client/pull/37[#37])
+* https://issues.couchbase.com/browse/RCBC-399[RCBC-399]: Add default options objects as class constants. (https://github.com/couchbase/couchbase-ruby-client/pull/69[#69])
 
 Notable changes in C++ SDK 1.0.0-beta.5:
 
@@ -122,74 +122,74 @@ Notable changes in C++ SDK 1.0.0-beta.5:
 * https://issues.couchbase.com/browse/CXXCBC-291[CXXCBC-291]: Allow to disable mutation tokens for Key/Value mutations (use `enable_mutation_tokens` in connection string).
 
 * Resource management and performance improvements:
-    * Fix tracer and meter ref-counting (https://github.com/couchbase/docs-sdk-ruby/pull/370[#370])
-    * Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (https://github.com/couchbase/docs-sdk-ruby/pull/356[#356])
-    * https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: Write to sockets from IO threads, to eliminate potential race conditions. (https://github.com/couchbase/docs-sdk-ruby/pull/348[#348])
-    * Eliminate looping transform in `mcbp_parser::next` (https://github.com/couchbase/docs-sdk-ruby/pull/347[#347])
-    * https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: Use thread-local UUID generator (https://github.com/couchbase/docs-sdk-ruby/pull/340[#340])
+    * Fix tracer and meter ref-counting (https://github.com/couchbaselabs/couchbase-cxx-client/pull/370[#370])
+    * Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (https://github.com/couchbaselabs/couchbase-cxx-client/pull/356[#356])
+    * https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: Write to sockets from IO threads, to eliminate potential race conditions. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/348[#348])
+    * Eliminate looping transform in `mcbp_parser::next` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/347[#347])
+    * https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: Use thread-local UUID generator (https://github.com/couchbaselabs/couchbase-cxx-client/pull/340[#340])
     * https://issues.couchbase.com/browse/CXXCBC-293[CXXCBC-293]: Performance improvements:
-        * Speed up UUID serialization to string (https://github.com/couchbase/docs-sdk-ruby/pull/346[#346])
-        * Don't allow to copy `mcbp_message` objects (https://github.com/couchbase/docs-sdk-ruby/pull/345[#345])
-        * Avoid extra allocation and initialization (https://github.com/couchbase/docs-sdk-ruby/pull/344[#344])
+        * Speed up UUID serialization to string (https://github.com/couchbaselabs/couchbase-cxx-client/pull/346[#346])
+        * Don't allow to copy `mcbp_message` objects (https://github.com/couchbaselabs/couchbase-cxx-client/pull/345[#345])
+        * Avoid extra allocation and initialization (https://github.com/couchbaselabs/couchbase-cxx-client/pull/344[#344])
 
 * Build system fixes:
-    * Fix build with gcc-13 (https://github.com/couchbase/docs-sdk-ruby/pull/372[#372])
-    * Fix gcc 12 issue (https://github.com/couchbase/docs-sdk-ruby/pull/367[#367])
+    * Fix build with gcc-13 (https://github.com/couchbaselabs/couchbase-cxx-client/pull/372[#372])
+    * Fix gcc 12 issue (https://github.com/couchbaselabs/couchbase-cxx-client/pull/367[#367])
 
 * Enhancements:
-    * Include bucketless KV service when ping is requested. (https://github.com/couchbase/docs-sdk-ruby/pull/339[#339])
-    * Include OS name in SDK identifier (https://github.com/couchbase/docs-sdk-ruby/pull/349[#349])
+    * Include bucketless KV service when ping is requested. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/339[#339])
+    * Include OS name in SDK identifier (https://github.com/couchbaselabs/couchbase-cxx-client/pull/349[#349])
 
 Notable changes in C++ SDK 1.0.0-beta.4
 
-* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (https://github.com/couchbase/docs-sdk-ruby/pull/336[#336])
+* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/336[#336])
 
 
 Notable changes in C++ SDK 1.0.0-dp.2
 
-* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: Drain waiting commands list on MCBP session close (https://github.com/couchbase/docs-sdk-ruby/pull/321[#321])
-* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (https://github.com/couchbase/docs-sdk-ruby/pull/322[#322])
+* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: Drain waiting commands list on MCBP session close (https://github.com/couchbaselabs/couchbase-cxx-client/pull/321[#321])
+* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/322[#322])
 
 Notable changes in C++ SDK 1.0.0-dp.1
 
-* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: Update SRV resolution for Windows (https://github.com/couchbase/docs-sdk-ruby/pull/303[#303])
+* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: Update SRV resolution for Windows (https://github.com/couchbaselabs/couchbase-cxx-client/pull/303[#303])
 * https://issues.couchbase.com/browse/CXXCBC-172[CXXCBC-172]: Refresh DNS SRV when cluster uncontactable (#275, #290)
 * https://issues.couchbase.com/browse/CXXCBC-234[CXXCBC-234]: Error message for bucket hibernation and update error message for authentication_failure. (#280, #285)
 * https://issues.couchbase.com/browse/CXXCBC-235[CXXCBC-235]: Load system CAs when the trust certificate is not provided and do not fail if trust certificate is not specified (#283, #281)
-* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: Fix encoding of durability frame (https://github.com/couchbase/docs-sdk-ruby/pull/277[#277])
-* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: Convert `not_stored` code to `document_exists` (https://github.com/couchbase/docs-sdk-ruby/pull/278[#278])
-* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: Fix snappy decompression for `get_replica` (https://github.com/couchbase/docs-sdk-ruby/pull/296[#296])
-* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: `query_options` not setting `scope_qualifier` (https://github.com/couchbase/docs-sdk-ruby/pull/300[#300])
-* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: Fix failures in serverless mode (https://github.com/couchbase/docs-sdk-ruby/pull/274[#274])
-* Don't log expected warnings in DNS resolver (https://github.com/couchbase/docs-sdk-ruby/pull/294[#294])
+* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: Fix encoding of durability frame (https://github.com/couchbaselabs/couchbase-cxx-client/pull/277[#277])
+* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: Convert `not_stored` code to `document_exists` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/278[#278])
+* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: Fix snappy decompression for `get_replica` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/296[#296])
+* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: `query_options` not setting `scope_qualifier` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/300[#300])
+* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: Fix failures in serverless mode (https://github.com/couchbaselabs/couchbase-cxx-client/pull/274[#274])
+* Don't log expected warnings in DNS resolver (https://github.com/couchbaselabs/couchbase-cxx-client/pull/294[#294])
 
 Resource management and performance fixes:
-* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: don't throw exceptions when socket options cannot be set (https://github.com/couchbase/docs-sdk-ruby/pull/270[#270])
+* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: don't throw exceptions when socket options cannot be set (https://github.com/couchbaselabs/couchbase-cxx-client/pull/270[#270])
 
 Build system fixes:
-* Move away from `reinterpret_pointer_cast<>` for MacOS build issue (https://github.com/couchbase/docs-sdk-ruby/pull/288[#288])
-* Improve OpenSSL detection on Windows (https://github.com/couchbase/docs-sdk-ruby/pull/272[#272])
+* Move away from `reinterpret_pointer_cast<>` for MacOS build issue (https://github.com/couchbaselabs/couchbase-cxx-client/pull/288[#288])
+* Improve OpenSSL detection on Windows (https://github.com/couchbaselabs/couchbase-cxx-client/pull/272[#272])
 
 Notable changes in C++ SDK 1.0.0-beta.3
 
-* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: Support for configuration profiles (https://github.com/couchbase/docs-sdk-ruby/pull/268[#268])
-* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: allow to check if subdoc result field has value (https://github.com/couchbase/docs-sdk-ruby/pull/263[#263])
-* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: Always set `kv_collection_outdated` retry reason on unknown collection error (https://github.com/couchbase/docs-sdk-ruby/pull/223[#223])
-* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: disable clustermap nofication by default (https://github.com/couchbase/docs-sdk-ruby/pull/233[#233])
-* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: Increment/decrement should not have `preserve_expiry` (https://github.com/couchbase/docs-sdk-ruby/pull/201[#201])
+* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: Support for configuration profiles (https://github.com/couchbaselabs/couchbase-cxx-client/pull/268[#268])
+* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: allow to check if subdoc result field has value (https://github.com/couchbaselabs/couchbase-cxx-client/pull/263[#263])
+* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: Always set `kv_collection_outdated` retry reason on unknown collection error (https://github.com/couchbaselabs/couchbase-cxx-client/pull/223[#223])
+* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: disable clustermap nofication by default (https://github.com/couchbaselabs/couchbase-cxx-client/pull/233[#233])
+* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: Increment/decrement should not have `preserve_expiry` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/201[#201])
 * https://issues.couchbase.com/browse/CXXCBC-55[CXXCBC-55]: External Tracing and Metrics support with OpenTelemetry support (#228, #231)
-* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: Add log forwarding (https://github.com/couchbase/docs-sdk-ruby/pull/206[#206])
+* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: Add log forwarding (https://github.com/couchbaselabs/couchbase-cxx-client/pull/206[#206])
 
 Bug fixes:
-* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: Close http_session before conecting to next endpoint (https://github.com/couchbase/docs-sdk-ruby/pull/213[#213])
-* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: fix parsing responses with chunked meta trailer (https://github.com/couchbase/docs-sdk-ruby/pull/191[#191])
-* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: add extra check for missing CA for TLS connections (https://github.com/couchbase/docs-sdk-ruby/pull/197[#197])
-* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: add extra check for keywords in query index fields (https://github.com/couchbase/docs-sdk-ruby/pull/196[#196])
-* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: complete streaming lexer even if pointer didn't match (https://github.com/couchbase/docs-sdk-ruby/pull/195[#195])
-* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: reprepare and retry query on 4040, 4050 and 4070 (https://github.com/couchbase/docs-sdk-ruby/pull/257[#257])
-* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: reduce scope of the http request lock (https://github.com/couchbase/docs-sdk-ruby/pull/259[#259])
-* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: ignore 'is_primary' for named primary indexes when dropping (https://github.com/couchbase/docs-sdk-ruby/pull/202[#202])
-* return subdocument error context from future-based subdoc methods (https://github.com/couchbase/docs-sdk-ruby/pull/258[#258])
+* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: Close http_session before conecting to next endpoint (https://github.com/couchbaselabs/couchbase-cxx-client/pull/213[#213])
+* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: fix parsing responses with chunked meta trailer (https://github.com/couchbaselabs/couchbase-cxx-client/pull/191[#191])
+* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: add extra check for missing CA for TLS connections (https://github.com/couchbaselabs/couchbase-cxx-client/pull/197[#197])
+* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: add extra check for keywords in query index fields (https://github.com/couchbaselabs/couchbase-cxx-client/pull/196[#196])
+* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: complete streaming lexer even if pointer didn't match (https://github.com/couchbaselabs/couchbase-cxx-client/pull/195[#195])
+* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: reprepare and retry query on 4040, 4050 and 4070 (https://github.com/couchbaselabs/couchbase-cxx-client/pull/257[#257])
+* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: reduce scope of the http request lock (https://github.com/couchbaselabs/couchbase-cxx-client/pull/259[#259])
+* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: ignore 'is_primary' for named primary indexes when dropping (https://github.com/couchbaselabs/couchbase-cxx-client/pull/202[#202])
+* return subdocument error context from future-based subdoc methods (https://github.com/couchbaselabs/couchbase-cxx-client/pull/258[#258])
 
 
 [cols="9,5,19"]

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -97,100 +97,146 @@ ruby -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]'
 
 https://docs.couchbase.com/sdk-api/couchbase-ruby-client-3.4.0/index.html[API Reference]
 
-Improvements:
-* https://issues.couchbase.com/browse/RCBC-378[RCBC-378]: Implement change password for `Management::User` class. (https://github.com/couchbase/couchbase-ruby-client/pull/65[#65])
-* https://issues.couchbase.com/browse/RCBC-388[RCBC-388]: Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (https://github.com/couchbase/couchbase-ruby-client/pull/55[#55])
-* https://issues.couchbase.com/browse/RCBC-263[RCBC-263]: Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (https://github.com/couchbase/couchbase-ruby-client/pull/49[#49])
-* https://issues.couchbase.com/browse/RCBC-387[RCBC-387]: Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (https://github.com/couchbase/couchbase-ruby-client/pull/48[#48])
-* https://issues.couchbase.com/browse/RCBC-375[RCBC-375]: Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (https://github.com/couchbase/couchbase-ruby-client/pull/45[#45])
-* https://issues.couchbase.com/browse/RCBC-371[RCBC-371]: Return id for `*_multi` results. (https://github.com/couchbase/couchbase-ruby-client/pull/40[#40])
-* https://issues.couchbase.com/browse/RCBC-393[RCBC-393]: Fix type conversion for query metrics. (https://github.com/couchbase/couchbase-ruby-client/pull/62[#62])
-* https://issues.couchbase.com/browse/RCBC-398[RCBC-398]: Add `ClusterRegistry` to allow custom connection string handlers. (https://github.com/couchbase/couchbase-ruby-client/pull/68[#68])
-* https://issues.couchbase.com/browse/RCBC-366[RCBC-366]: Allow to override default timeouts through `Options::Cluster` (https://github.com/couchbase/couchbase-ruby-client/pull/37[#37])
-* https://issues.couchbase.com/browse/RCBC-399[RCBC-399]: Add default options objects as class constants. (https://github.com/couchbase/couchbase-ruby-client/pull/69[#69])
+=== Improvements
 
-Notable changes in C++ SDK 1.0.0-beta.5:
+* https://issues.couchbase.com/browse/RCBC-378[RCBC-378]: 
+Implement change password for `Management::User` class. (https://github.com/couchbase/couchbase-ruby-client/pull/65[#65])
+* https://issues.couchbase.com/browse/RCBC-388[RCBC-388]: 
+Add Configuration Profiles. At the moment one profile is defined `"wan_development"`, and it could be applied using `Options::Cluster#apply_profile`.  (https://github.com/couchbase/couchbase-ruby-client/pull/55[#55])
+* https://issues.couchbase.com/browse/RCBC-263[RCBC-263]: 
+Implement legacy durability. See options `:persist_to` and `:replicate_to` of mutations. (https://github.com/couchbase/couchbase-ruby-client/pull/49[#49])
+* https://issues.couchbase.com/browse/RCBC-387[RCBC-387]: 
+Implement replica reads with `Collection#get_any_replica` and `Couchbase#get_all_replicas` (https://github.com/couchbase/couchbase-ruby-client/pull/48[#48])
+* https://issues.couchbase.com/browse/RCBC-375[RCBC-375]: 
+Implement log forwarding. See documentation of method `Couchbase.set_logger` and classes `Couchbase::Utils::GenericLoggerAdapter`, `Couchbase::Utils::GenericLoggerAdapter` (https://github.com/couchbase/couchbase-ruby-client/pull/45[#45])
+* https://issues.couchbase.com/browse/RCBC-371[RCBC-371]: 
+Return id for `*_multi` results. (https://github.com/couchbase/couchbase-ruby-client/pull/40[#40])
+* https://issues.couchbase.com/browse/RCBC-393[RCBC-393]: 
+Fix type conversion for query metrics. (https://github.com/couchbase/couchbase-ruby-client/pull/62[#62])
+* https://issues.couchbase.com/browse/RCBC-398[RCBC-398]: 
+Add `ClusterRegistry` to allow custom connection string handlers. (https://github.com/couchbase/couchbase-ruby-client/pull/68[#68])
+* https://issues.couchbase.com/browse/RCBC-366[RCBC-366]: 
+Allow to override default timeouts through `Options::Cluster` (https://github.com/couchbase/couchbase-ruby-client/pull/37[#37])
+* https://issues.couchbase.com/browse/RCBC-399[RCBC-399]: 
+Add default options objects as class constants. (https://github.com/couchbase/couchbase-ruby-client/pull/69[#69])
 
-* https://issues.couchbase.com/browse/CXXCBC-275[CXXCBC-275]: Update implementation query context fields passed to the server. In future versions of the server versions it will become mandatory to specify context of the statement (bucket, scope and collection). This change ensures that both future and current server releases supported transparently.
+=== Underlying C++ SDK Core
 
-* https://issues.couchbase.com/browse/CXXCBC-296[CXXCBC-296]: Force PLAIN SASL auth if TLS enabled. Using SCRAM SASL mechanisms over TLS protocol is unnecesary complication, that slows down initial connection bootstrap and potentially limits server ability to improve security and evolve credentials management.
+==== Notable Changes in C++ SDK 1.0.0-beta.5
 
-* https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-295]: The `get with projections` opration should not fail if one of the the paths is missing in the document, because the semantics is "get the partial document" and not "get individual fields" like in `lookup_in` operation.
-
-* https://issues.couchbase.com/browse/CXXCBC-294[CXXCBC-294]: In the Public API, if `get` operation requested to return expiry time, zero expiry should not be interpreted as absolute expiry timestamp (zero seconds from UNIX epoch), but rather as absense of the expiry.
-
-* https://issues.couchbase.com/browse/CXXCBC-291[CXXCBC-291]: Allow to disable mutation tokens for Key/Value mutations (use `enable_mutation_tokens` in connection string).
-
+* https://issues.couchbase.com/browse/CXXCBC-275[CXXCBC-275]: 
+Update implementation query context fields passed to the server. In future versions of the server versions it will become mandatory to specify context of the statement (bucket, scope and collection). 
+This change ensures that both future and current server releases supported transparently.
+* https://issues.couchbase.com/browse/CXXCBC-296[CXXCBC-296]: 
+Force PLAIN SASL auth if TLS enabled. Using SCRAM SASL mechanisms over TLS protocol is unnecesary complication, that slows down initial connection bootstrap and potentially limits server ability to improve security and evolve credentials management.
+* https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-295]: 
+The `get with projections` opration should not fail if one of the the paths is missing in the document, because the semantics is "get the partial document" and not "get individual fields" like in `lookup_in` operation.
+* https://issues.couchbase.com/browse/CXXCBC-294[CXXCBC-294]: 
+In the Public API, if `get` operation requested to return expiry time, zero expiry should not be interpreted as absolute expiry timestamp (zero seconds from UNIX epoch), but rather as absense of the expiry.
+* https://issues.couchbase.com/browse/CXXCBC-291[CXXCBC-291]: 
+Allow to disable mutation tokens for Key/Value mutations (use `enable_mutation_tokens` in connection string).
 * Resource management and performance improvements:
-    * Fix tracer and meter ref-counting (https://github.com/couchbaselabs/couchbase-cxx-client/pull/370[#370])
-    * Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (https://github.com/couchbaselabs/couchbase-cxx-client/pull/356[#356])
-    * https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: Write to sockets from IO threads, to eliminate potential race conditions. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/348[#348])
-    * Eliminate looping transform in `mcbp_parser::next` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/347[#347])
-    * https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: Use thread-local UUID generator (https://github.com/couchbaselabs/couchbase-cxx-client/pull/340[#340])
-    * https://issues.couchbase.com/browse/CXXCBC-293[CXXCBC-293]: Performance improvements:
-        * Speed up UUID serialization to string (https://github.com/couchbaselabs/couchbase-cxx-client/pull/346[#346])
-        * Don't allow to copy `mcbp_message` objects (https://github.com/couchbaselabs/couchbase-cxx-client/pull/345[#345])
-        * Avoid extra allocation and initialization (https://github.com/couchbaselabs/couchbase-cxx-client/pull/344[#344])
-
+** Fix tracer and meter ref-counting (https://github.com/couchbaselabs/couchbase-cxx-client/pull/370[#370])
+** Replace `minstd_rand` with `mt19937_64`, as it gives less collisions (https://github.com/couchbaselabs/couchbase-cxx-client/pull/356[#356])
+** https://issues.couchbase.com/browse/CXXCBC-285[CXXCBC-285]: 
+Write to sockets from IO threads, to eliminate potential race conditions. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/348[#348])
+** Eliminate looping transform in `mcbp_parser::next` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/347[#347])
+** https://issues.couchbase.com/browse/CXXCBC-295[CXXCBC-205]: 
+Use thread-local UUID generator (https://github.com/couchbaselabs/couchbase-cxx-client/pull/340[#340])
+** https://issues.couchbase.com/browse/CXXCBC-293[CXXCBC-293]: 
+Performance improvements:
+*** Speed up UUID serialization to string (https://github.com/couchbaselabs/couchbase-cxx-client/pull/346[#346])
+*** Don't allow to copy `mcbp_message` objects (https://github.com/couchbaselabs/couchbase-cxx-client/pull/345[#345])
+*** Avoid extra allocation and initialization (https://github.com/couchbaselabs/couchbase-cxx-client/pull/344[#344])
 * Build system fixes:
-    * Fix build with gcc-13 (https://github.com/couchbaselabs/couchbase-cxx-client/pull/372[#372])
-    * Fix gcc 12 issue (https://github.com/couchbaselabs/couchbase-cxx-client/pull/367[#367])
-
+** Fix build with gcc-13 (https://github.com/couchbaselabs/couchbase-cxx-client/pull/372[#372])
+** Fix gcc 12 issue (https://github.com/couchbaselabs/couchbase-cxx-client/pull/367[#367])
 * Enhancements:
-    * Include bucketless KV service when ping is requested. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/339[#339])
-    * Include OS name in SDK identifier (https://github.com/couchbaselabs/couchbase-cxx-client/pull/349[#349])
+** Include bucketless KV service when ping is requested. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/339[#339])
+** Include OS name in SDK identifier (https://github.com/couchbaselabs/couchbase-cxx-client/pull/349[#349])
 
-Notable changes in C++ SDK 1.0.0-beta.4
+==== Notable changes in C++ SDK 1.0.0-beta.4
 
-* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/336[#336])
+* https://issues.couchbase.com/CXXCBC-276[CXXCBC-276]: 
+Use interval from the options for config poll, which previous was hard-coded to 2.5 seconds. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/336[#336])
 
+==== Notable changes in C++ SDK 1.0.0-dp.2
 
-Notable changes in C++ SDK 1.0.0-dp.2
+* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: 
+Drain waiting commands list on MCBP session close (https://github.com/couchbaselabs/couchbase-cxx-client/pull/321[#321])
+* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: 
+Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/322[#322])
 
-* https://issues.couchbase.com/browse/CXXCBC-242[CXXCBC-242]: Drain waiting commands list on MCBP session close (https://github.com/couchbaselabs/couchbase-cxx-client/pull/321[#321])
-* https://issues.couchbase.com/browse/CXXCBC-271[CXXCBC-271]: Fix `get_all_replicas` behaviour: do not propagate error if result set is not empty, while the last response has failed. (https://github.com/couchbaselabs/couchbase-cxx-client/pull/322[#322])
+==== Notable changes in C++ SDK 1.0.0-dp.1
 
-Notable changes in C++ SDK 1.0.0-dp.1
-
-* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: Update SRV resolution for Windows (https://github.com/couchbaselabs/couchbase-cxx-client/pull/303[#303])
-* https://issues.couchbase.com/browse/CXXCBC-172[CXXCBC-172]: Refresh DNS SRV when cluster uncontactable (#275, #290)
-* https://issues.couchbase.com/browse/CXXCBC-234[CXXCBC-234]: Error message for bucket hibernation and update error message for authentication_failure. (#280, #285)
-* https://issues.couchbase.com/browse/CXXCBC-235[CXXCBC-235]: Load system CAs when the trust certificate is not provided and do not fail if trust certificate is not specified (#283, #281)
-* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: Fix encoding of durability frame (https://github.com/couchbaselabs/couchbase-cxx-client/pull/277[#277])
-* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: Convert `not_stored` code to `document_exists` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/278[#278])
-* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: Fix snappy decompression for `get_replica` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/296[#296])
-* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: `query_options` not setting `scope_qualifier` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/300[#300])
-* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: Fix failures in serverless mode (https://github.com/couchbaselabs/couchbase-cxx-client/pull/274[#274])
+* https://issues.couchbase.com/browse/CXXCBC-142[CXXCBC-142]: 
+Update SRV resolution for Windows (https://github.com/couchbaselabs/couchbase-cxx-client/pull/303[#303])
+* https://issues.couchbase.com/browse/CXXCBC-172[CXXCBC-172]: 
+Refresh DNS SRV when cluster uncontactable (#275, #290)
+* https://issues.couchbase.com/browse/CXXCBC-234[CXXCBC-234]: 
+Error message for bucket hibernation and update error message for authentication_failure. (#280, #285)
+* https://issues.couchbase.com/browse/CXXCBC-235[CXXCBC-235]: 
+Load system CAs when the trust certificate is not provided and do not fail if trust certificate is not specified (#283, #281)
+* https://issues.couchbase.com/browse/CXXCBC-245[CXXCBC-245]: 
+Fix encoding of durability frame (https://github.com/couchbaselabs/couchbase-cxx-client/pull/277[#277])
+* https://issues.couchbase.com/browse/CXXCBC-246[CXXCBC-246]: 
+Convert `not_stored` code to `document_exists` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/278[#278])
+* https://issues.couchbase.com/browse/CXXCBC-251[CXXCBC-251]: 
+Fix snappy decompression for `get_replica` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/296[#296])
+* https://issues.couchbase.com/browse/CXXCBC-253[CXXCBC-253]: 
+`query_options` not setting `scope_qualifier` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/300[#300])
+* https://issues.couchbase.com/browse/SDKQE-2761[SDKQE-2761]: 
+Fix failures in serverless mode (https://github.com/couchbaselabs/couchbase-cxx-client/pull/274[#274])
 * Don't log expected warnings in DNS resolver (https://github.com/couchbaselabs/couchbase-cxx-client/pull/294[#294])
 
-Resource management and performance fixes:
-* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: don't throw exceptions when socket options cannot be set (https://github.com/couchbaselabs/couchbase-cxx-client/pull/270[#270])
+==== Resource management and performance fixes
 
-Build system fixes:
+* https://issues.couchbase.com/browse/CXXCBC-225[CXXCBC-225]: 
+Don't throw exceptions when socket options cannot be set (https://github.com/couchbaselabs/couchbase-cxx-client/pull/270[#270])
+
+==== Build system fixes
+
 * Move away from `reinterpret_pointer_cast<>` for MacOS build issue (https://github.com/couchbaselabs/couchbase-cxx-client/pull/288[#288])
 * Improve OpenSSL detection on Windows (https://github.com/couchbaselabs/couchbase-cxx-client/pull/272[#272])
 
-Notable changes in C++ SDK 1.0.0-beta.3
+==== Notable changes in C++ SDK 1.0.0-beta.3
 
-* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: Support for configuration profiles (https://github.com/couchbaselabs/couchbase-cxx-client/pull/268[#268])
-* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: allow to check if subdoc result field has value (https://github.com/couchbaselabs/couchbase-cxx-client/pull/263[#263])
-* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: Always set `kv_collection_outdated` retry reason on unknown collection error (https://github.com/couchbaselabs/couchbase-cxx-client/pull/223[#223])
-* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: disable clustermap nofication by default (https://github.com/couchbaselabs/couchbase-cxx-client/pull/233[#233])
-* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: Increment/decrement should not have `preserve_expiry` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/201[#201])
-* https://issues.couchbase.com/browse/CXXCBC-55[CXXCBC-55]: External Tracing and Metrics support with OpenTelemetry support (#228, #231)
-* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: Add log forwarding (https://github.com/couchbaselabs/couchbase-cxx-client/pull/206[#206])
+* https://issues.couchbase.com/browse/CXXCBC-221[CXXCBC-221]: 
+Support for configuration profiles (https://github.com/couchbaselabs/couchbase-cxx-client/pull/268[#268])
+* https://issues.couchbase.com/browse/CXXCBC-218[CXXCBC-218]: 
+allow to check if subdoc result field has value (https://github.com/couchbaselabs/couchbase-cxx-client/pull/263[#263])
+* https://issues.couchbase.com/browse/CXXCBC-199[CXXCBC-199]: 
+Always set `kv_collection_outdated` retry reason on unknown collection error (https://github.com/couchbaselabs/couchbase-cxx-client/pull/223[#223])
+* https://issues.couchbase.com/browse/CXXCBC-203[CXXCBC-203]: 
+disable clustermap nofication by default (https://github.com/couchbaselabs/couchbase-cxx-client/pull/233[#233])
+* https://issues.couchbase.com/browse/CXXCBC-159[CXXCBC-159]: 
+Increment/decrement should not have `preserve_expiry` (https://github.com/couchbaselabs/couchbase-cxx-client/pull/201[#201])
+* https://issues.couchbase.com/browse/CXXCBC-55[CXXCBC-55]: 
+External Tracing and Metrics support with OpenTelemetry support (#228, #231)
+* https://issues.couchbase.com/browse/CXXCBC-54[CXXCBC-54]: 
+Add log forwarding (https://github.com/couchbaselabs/couchbase-cxx-client/pull/206[#206])
 
-Bug fixes:
-* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: Close http_session before conecting to next endpoint (https://github.com/couchbaselabs/couchbase-cxx-client/pull/213[#213])
-* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: fix parsing responses with chunked meta trailer (https://github.com/couchbaselabs/couchbase-cxx-client/pull/191[#191])
-* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: add extra check for missing CA for TLS connections (https://github.com/couchbaselabs/couchbase-cxx-client/pull/197[#197])
-* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: add extra check for keywords in query index fields (https://github.com/couchbaselabs/couchbase-cxx-client/pull/196[#196])
-* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: complete streaming lexer even if pointer didn't match (https://github.com/couchbaselabs/couchbase-cxx-client/pull/195[#195])
-* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: reprepare and retry query on 4040, 4050 and 4070 (https://github.com/couchbaselabs/couchbase-cxx-client/pull/257[#257])
-* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: reduce scope of the http request lock (https://github.com/couchbaselabs/couchbase-cxx-client/pull/259[#259])
-* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: ignore 'is_primary' for named primary indexes when dropping (https://github.com/couchbaselabs/couchbase-cxx-client/pull/202[#202])
-* return subdocument error context from future-based subdoc methods (https://github.com/couchbaselabs/couchbase-cxx-client/pull/258[#258])
+==== Bug fixes
 
+* https://issues.couchbase.com/browse/CXXCBC-134[CXXCBC-134]: 
+Close http_session before conecting to next endpoint (https://github.com/couchbaselabs/couchbase-cxx-client/pull/213[#213])
+* https://issues.couchbase.com/browse/CXXCBC-179[CXXCBC-179]: 
+fix parsing responses with chunked meta trailer (https://github.com/couchbaselabs/couchbase-cxx-client/pull/191[#191])
+* https://issues.couchbase.com/browse/CXXCBC-170[CXXCBC-170]: 
+add extra check for missing CA for TLS connections (https://github.com/couchbaselabs/couchbase-cxx-client/pull/197[#197])
+* https://issues.couchbase.com/browse/CXXCBC-182[CXXCBC-182]: 
+add extra check for keywords in query index fields (https://github.com/couchbaselabs/couchbase-cxx-client/pull/196[#196])
+* https://issues.couchbase.com/browse/CXXCBC-173[CXXCBC-173]: 
+complete streaming lexer even if pointer didn't match (https://github.com/couchbaselabs/couchbase-cxx-client/pull/195[#195])
+* https://issues.couchbase.com/browse/CXXCBC-212[CXXCBC-212]: 
+reprepare and retry query on 4040, 4050 and 4070 (https://github.com/couchbaselabs/couchbase-cxx-client/pull/257[#257])
+* https://issues.couchbase.com/browse/CXXCBC-174[CXXCBC-174]: 
+reduce scope of the http request lock (https://github.com/couchbaselabs/couchbase-cxx-client/pull/259[#259])
+* https://issues.couchbase.com/browse/CXXCBC-176[CXXCBC-176]: 
+ignore 'is_primary' for named primary indexes when dropping (https://github.com/couchbaselabs/couchbase-cxx-client/pull/202[#202])
+* Return subdocument error context from future-based subdoc methods (https://github.com/couchbaselabs/couchbase-cxx-client/pull/258[#258])
+
+=== Download Links
 
 [cols="9,5,19"]
 |===

--- a/modules/project-docs/partials/attributes.adoc
+++ b/modules/project-docs/partials/attributes.adoc
@@ -2,4 +2,4 @@
 :ruby-current-version: 3.4.0
 :name-sdk: Ruby SDK
 :version-server: 7.1
-:version-common: 7.1.2
+:version-common: 7.1.3

--- a/modules/project-docs/partials/attributes.adoc
+++ b/modules/project-docs/partials/attributes.adoc
@@ -1,5 +1,5 @@
 :ruby-api-link: https://docs.couchbase.com/sdk-api/couchbase-ruby-client/index.html
-:ruby-current-version: 3.3.0
+:ruby-current-version: 3.4.0
 :name-sdk: Ruby SDK
 :version-server: 7.1
 :version-common: 7.1.2


### PR DESCRIPTION
It includes some picks from C++SDK release notes, which are not hosted on the documentation sites yet, but available on github releases for the project: https://github.com/couchbaselabs/couchbase-cxx-client/releases