### PR TITLE
RCBC-435: Improve TLS Documentation

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -126,25 +126,25 @@ The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FI
 
 Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` parameter in the connection string.
 
-The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. If you have debug-level logging enabled the metadata will be outputted after the {cbpp} core is initialized.
+The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the relevant metadata using the following command:
 
-[source]
+====
+[source,console]
 ----
-[2023-05-16 14:13:39.593] [debug] couchbase backend build info:
-{
- ...
- :mozilla_ca_bundle_date=>"Tue Jan 10 04:12:06 2023 GMT",
+$ ruby -rcouchbase -e 'pp Couchbase::BUILD_INFO[:cxx_client].select{|k, _| k =~ /^(mozilla|openssl_default)/}'
+----
+[source,console]
+----
+{:mozilla_ca_bundle_date=>"Tue Jan 10 04:12:06 2023 GMT",
  :mozilla_ca_bundle_embedded=>true,
  :mozilla_ca_bundle_sha256=>"fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0",
  :mozilla_ca_bundle_size=>137,
- ...
- :openssl_default_cert_dir=>"/opt/homebrew/etc/openssl@1.1/certs",
+ :openssl_default_cert_dir=>"/etc/pki/tls/certs",
  :openssl_default_cert_dir_env=>"SSL_CERT_DIR",
- :openssl_default_cert_file=>"/opt/homebrew/etc/openssl@1.1/cert.pem",
- :openssl_default_cert_file_env=>"SSL_CERT_FILE",
- ...
-}
+ :openssl_default_cert_file=>"/etc/pki/tls/cert.pem",
+ :openssl_default_cert_file_env=>"SSL_CERT_FILE"}
 ----
+====
 
 With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information about the version of the Mozilla CA certificate store will be outputted. For example:
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -133,7 +133,7 @@ The {cbpp} core's metadata provide information about where OpenSSL's default cer
 ----
 $ ruby -r couchbase -e 'pp Couchbase::BUILD_INFO[:cxx_client].select{|k, _| k =~ /^(mozilla|openssl_default)/}'
 ----
-[source,console]
+[source,ruby]
 ----
 {:mozilla_ca_bundle_date=>"Tue Jan 10 04:12:06 2023 GMT",
  :mozilla_ca_bundle_embedded=>true,

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -128,6 +128,7 @@ Loading the Mozilla certificates can be disabled by setting the `disable_mozilla
 
 The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. If you have debug-level logging enabled the metadata will be outputted after the {cbpp} core is initialized.
 
+[source]
 ----
 [2023-05-16 14:13:39.593] [debug] couchbase backend build info:
 {
@@ -147,6 +148,7 @@ The {cbpp} core's metadata provide information about where OpenSSL's default cer
 
 With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information about the version of the Mozilla CA certificate store will be outputted. For example:
 
+[source]
 ----
 loading 137 CA certificates from Mozilla bundle. Update date: "Tue Jan 10 04:12:06 2023 GMT", SHA256: "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0"
 ----

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -113,8 +113,43 @@ NOTE: Any TLS certificates must be set up at the point where the connections are
 == Secure Connections
 
 Couchbase Server Enterprise Edition and Couchbase Capella support full encryption of client-side traffic using Transport Layer Security (TLS).
-That includes key-value type operations, queries, and configuration communication.
+This includes key-value type operations, queries, and configuration communication.
 Make sure you have the Enterprise Edition of Couchbase Server, or a Couchbase Capella account, before proceeding with configuring encryption on the client side.
+
+For TLS certificate verification the SDK uses the following CA certificates:
+
+* The certificates in the Mozilla Root CA bundle (bundled with the SDK as of 3.4.3 and obtained from https://curl.se/docs/caextract.html[curl])
+* The certificates in OpenSSL's default CA certificate store (as of SDK 3.4.0)
+* The self-signed root certificate that is used to sign the Couchbase Capella certificates (bundled with the SDK as of 3.3.0)
+
+The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates. More information can be found in the relevant https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_load_verify_locations.html[OpenSSL documentation].
+
+Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` parameter in the connection string.
+
+The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. If you have debug-level logging enabled the metadata will be outputted after the {cbpp} core is initialized.
+
+----
+[2023-05-16 14:13:39.593] [debug] couchbase backend build info:
+{
+ ...
+ :mozilla_ca_bundle_date=>"Tue Jan 10 04:12:06 2023 GMT",
+ :mozilla_ca_bundle_embedded=>true,
+ :mozilla_ca_bundle_sha256=>"fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0",
+ :mozilla_ca_bundle_size=>137,
+ ...
+ :openssl_default_cert_dir=>"/opt/homebrew/etc/openssl@1.1/certs",
+ :openssl_default_cert_dir_env=>"SSL_CERT_DIR",
+ :openssl_default_cert_file=>"/opt/homebrew/etc/openssl@1.1/cert.pem",
+ :openssl_default_cert_file_env=>"SSL_CERT_FILE",
+ ...
+}
+----
+
+With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information about the version of the Mozilla CA certificate store will be outputted. For example:
+
+----
+loading 137 CA certificates from Mozilla bundle. Update date: "Tue Jan 10 04:12:06 2023 GMT", SHA256: "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0"
+----
 
 [{tabs}]
 ====
@@ -131,23 +166,7 @@ However, as the certificate is bundled with the SDK, it is trusted by default.
 Couchbase Server::
 +
 --
-As of SDK 3.4, if you connect to a Couchbase Server cluster with a root certificate issued by a trusted CA (Certificate Authority), you no longer need to configure the `trust_certificate` path in your connection string.
-
-The cluster's root certificate just needs to be issued by a CA whose certificate is in your OpenSSL trust store.
-This can include publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
-The Ruby SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the root CAs.
-
-IMPORTANT: {cbpp} loads OpenSSL's root CA store, therefore you should make sure that your system or platform is configured to support this.
-
-Depending on your OpenSSL installation, OpenSSL might not contain any certificates in its CA store by default, which you might wish to populate.
-You can find the location of the OpenSSL executable used by Ruby with the following command:
-
-[source,console]
-----
-ruby -r rbconfig -e 'puts RbConfig::CONFIG["configure_args"]'
-----
-
-To locate the directory where OpenSSL stores trusted certificates, you can run `./openssl version -d` -- where `openssl` is the relevant OpenSSL executable.
+Certificates from the Mozilla Root CA store are now bundled with the SDK (as of version 3.4.3). If the server's certificate is signed by a well-known CA (e.g., GoDaddy, Verisign, etc.), you don't need to configure the `trust_certificate` path in your connection string  -- simply use `couchbases://`.
 
 You can still provide a certificate explicitly if necessary:
 
@@ -160,7 +179,7 @@ so either copy it through SSH or through a similar secure mechanism.
 If you are running on `localhost` and just want to enable TLS for a development machine, just copying and pasting it suffices
 -- _so long as you use `127.0.0.1` rather than `localhost` in the connection string_.
 This is because the certificate will not match the name _localhost_.
-Setting `TLSSkipVerify` is a workaround if you need to use ` couchbases://localhost`.
+Setting `tls_verify` to `none` is a workaround if you need to use `couchbases://localhost`.
 
 Navigate in the admin UI to menu:Settings[Cluster] and copy the input box of the TLS certificate into a file on your machine (which we will refer to as `cluster.crt`).  
 It looks similar to this:

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -118,15 +118,19 @@ Make sure you have the Enterprise Edition of Couchbase Server, or a Couchbase Ca
 
 For TLS certificate verification the SDK uses the following CA certificates:
 
-* The certificates in the Mozilla Root CA bundle (bundled with the SDK as of 3.4.3 and obtained from https://curl.se/docs/caextract.html[curl])
-* The certificates in OpenSSL's default CA certificate store (as of SDK 3.4.0)
-* The self-signed root certificate that is used to sign the Couchbase Capella certificates (bundled with the SDK as of 3.3.0)
+* The certificates in the Mozilla Root CA bundle (bundled with the SDK as of 3.4.3 and obtained from https://curl.se/docs/caextract.html[curl]).
+* The certificates in OpenSSL's default CA certificate store (as of SDK 3.4.0).
+* The self-signed root certificate that is used to sign the Couchbase Capella certificates (bundled with the SDK as of 3.3.0).
 
-The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates. More information can be found in the relevant https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_load_verify_locations.html[OpenSSL documentation].
+The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. 
+The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, 
+whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates. 
+More information can be found in the relevant https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_load_verify_locations.html[OpenSSL documentation].
 
 Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` parameter in the connection string.
 
-The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located, which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the relevant metadata using the following command:
+The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located, which version of the Mozilla CA certificate store was bundled, and other useful details. 
+You can get the relevant metadata using the following command:
 
 ====
 [source,console]
@@ -146,9 +150,10 @@ $ ruby -r couchbase -e 'pp Couchbase::BUILD_INFO[:cxx_client].select{|k, _| k =~
 ----
 ====
 
-With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information about the version of the Mozilla CA certificate store will be outputted. For example:
+With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information about the version of the Mozilla CA certificate store will be outputted. 
+For example:
 
-[source]
+[source,console]
 ----
 loading 137 CA certificates from Mozilla bundle. Update date: "Tue Jan 10 04:12:06 2023 GMT", SHA256: "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0"
 ----
@@ -168,7 +173,8 @@ However, as the certificate is bundled with the SDK, it is trusted by default.
 Couchbase Server::
 +
 --
-Certificates from the Mozilla Root CA store are now bundled with the SDK (as of version 3.4.3). If the server's certificate is signed by a well-known CA (e.g., GoDaddy, Verisign, etc.), you don't need to configure the `trust_certificate` path in your connection string  -- simply use `couchbases://`.
+Certificates from the Mozilla Root CA store are now bundled with the SDK (as of version 3.4.3). 
+If the server's certificate is signed by a well-known CA (e.g., GoDaddy, Verisign, etc.), you don't need to configure the `trust_certificate` path in your connection string  -- simply use `couchbases://`.
 
 You can still provide a certificate explicitly if necessary:
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -126,12 +126,12 @@ The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FI
 
 Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` parameter in the connection string.
 
-The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the relevant metadata using the following command:
+The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located, which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the relevant metadata using the following command:
 
 ====
 [source,console]
 ----
-$ ruby -rcouchbase -e 'pp Couchbase::BUILD_INFO[:cxx_client].select{|k, _| k =~ /^(mozilla|openssl_default)/}'
+$ ruby -r couchbase -e 'pp Couchbase::BUILD_INFO[:cxx_client].select{|k, _| k =~ /^(mozilla|openssl_default)/}'
 ----
 [source,console]
 ----


### PR DESCRIPTION
Added more details on TLS certificates & updated the information after the addition of the Mozilla certificates in version 3.4.3