### PR TITLE
[AV-82442] Update Ruby release 3.3 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -32,7 +32,7 @@ If you are connecting to https://docs.couchbase.com/cloud/index.html[Couchbase C
 include::hello-world:example$cloud.rb[tags=**]
 ----
 
-The Couchbase Capella free trial version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 --
 
 Local Couchbase Server::
@@ -82,7 +82,7 @@ The following code samples assume:
 * Couchbase xref:cloud:ROOT:index.adoc[Capella] cluster, or Couchbase Server is installed and accessible locally (xref:server:getting-started:do-a-quick-install.adoc[Do a Quick Install] if you don't already have Couchbase Server installed).
 
 * You have create a bucket (perhaps using the xref:server:manage:manage-settings/install-sample-buckets.adoc[travel-sample dataset], or by creating a new bucket).
-Note, the Travel Sample bucket is installed automatically by the Capella free trial
+Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
 
 * You have created a Couchbase user named "username" [change as appropriate] with permissions to access the cluster (at least Application Access permissions).
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -82,7 +82,7 @@ The following code samples assume:
 * Couchbase xref:cloud:ROOT:index.adoc[Capella] cluster, or Couchbase Server is installed and accessible locally (xref:server:getting-started:do-a-quick-install.adoc[Do a Quick Install] if you don't already have Couchbase Server installed).
 
 * You have create a bucket (perhaps using the xref:server:manage:manage-settings/install-sample-buckets.adoc[travel-sample dataset], or by creating a new bucket).
-Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella free tier cluster.
 
 * You have created a Couchbase user named "username" [change as appropriate] with permissions to access the cluster (at least Application Access permissions).
 


### PR DESCRIPTION
Removed mentions of trial in the Ruby SDK docs. Only locations found were the start-using-sdk.adoc page.