### PR TITLE
Added the preview/HEAD.yml file and the Tip for FTS Limits Cap

### DIFF
--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -22,6 +22,18 @@ Most of this documentation will focus on the former API, as the latter is in @St
 
 
 
+[TIP]
+.Search Results Limit
+====
+By default, the Search Service returns only the first 10 matches (`size: 10`, `from: 0`).
+To retrieve more results, you must explicitly define pagination settings such as `size` or `from` in your query.
+
+For information about formatting your Search query and specifying limits, see xref:server:search:search-request-params.adoc[].
+
+For information about pagination in Search responses, see xref:server:fts:fts-search-response.adoc#pagination[Pagination].
+====
+
+
 == Index Creation
 
 For the purposes of the below examples we will use the Beer Sample sample bucket.

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-devex:
+    branches: release/8.0


### PR DESCRIPTION
[DOC-14074](https://jira.issues.couchbase.com/browse/DOC-14074)

Added a TIP about the FTS search results limit. Added a couple of hyperlinks pointing to docs that reside in the docs-server and docs-devex repos.
Also added the directory and yml file, preview/HEAD.yml, since the docs-sdk-ruby repo did not have them.

[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-ruby-DOC-14074_Ruby_FTS_Limits_Cap/ruby-sdk/current/howtos/full-text-searching-with-sdk.html)

[DOC-14074]: https://couchbasecloud.atlassian.net/browse/DOC-14074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ