### PR TITLE
DOC-14062_Ruby_FTS to Search_name change

### DIFF
--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -1,5 +1,5 @@
 = Search
-:description: You can use the Search Service to create queryable, search indexes in Couchbase Server.
+:description: You can use the Search Service to create queryable Search indexes in Couchbase Server.
 :page-topic-type: howto
 :page-toclevels: 2
 :page-pagination: full
@@ -8,7 +8,7 @@
 {description}
 
 
-The Search Service -- or _Search_ for short -- allows you to create, manage, and query search indexes on JSON documents stored in Couchbase buckets. 
+The Search Service allows you to create, manage, and query Search indexes on JSON documents stored in Couchbase buckets. 
 It uses natural language processing for querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
 
 Some of the supported query types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
@@ -37,7 +37,7 @@ For information about pagination in Search responses, see xref:server:fts:fts-se
 == Index Creation
 
 For the purposes of the below examples we will use the Beer Sample sample bucket.
-The Search indexes can be xref:{version-server}@server:fts:fts-creating-indexes.adoc[created through the UI or throuth the REST API], or created programatically as follows:
+Search indexes can be xref:{version-server}@server:fts:fts-creating-indexes.adoc[created through the UI or throuth the REST API], or created programatically as follows:
 
 [source,ruby]
 ----
@@ -50,7 +50,7 @@ include::example$search.rb[tag=index]
 In versions of Couchbase Server starting from 7.6, Search queries are executed at either the Scope or the Cluster level;
 in earlier versions, they are just performed at the cluster level. (not bucket or collection). 
 
-We will perform an Search query here - see the <<vector search>> section for examples of that.
+We will perform a Search query here - see the <<vector search>> section for examples of that.
 Here is a simple query that looks for the text "hop beer" using the defined index:
 
 [source,ruby]

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -1,5 +1,5 @@
 = Search
-:description: You can use the Full Text Search service (FTS) to create queryable, full-text indexes in Couchbase Server.
+:description: You can use the Search Service to create queryable, search indexes in Couchbase Server.
 :page-topic-type: howto
 :page-toclevels: 2
 :page-pagination: full
@@ -8,7 +8,7 @@
 {description}
 
 
-Full Text Search (FTS) -- or _Search_ for short -- allows you to create, manage, and query full text indexes on JSON documents stored in Couchbase buckets. 
+The Search Service -- or _Search_ for short -- allows you to create, manage, and query search indexes on JSON documents stored in Couchbase buckets. 
 It uses natural language processing for querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
 
 Some of the supported query types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
@@ -17,7 +17,7 @@ Some of the supported query types include simple queries like Match and Term que
 There are two APIs for querying search: `cluster.searchQuery()`, and `cluster.search()`.
 Both are also available at the Scope level.
 
-The former API supports FTS queries (`SearchQuery`), while the latter additionally supports the `VectorSearch` added in 7.6.
+The former API supports Search queries (`SearchQuery`), while the latter additionally supports the `VectorSearch` added in 7.6.
 Most of this documentation will focus on the former API, as the latter is in @Stability.Volatile status.
 
 
@@ -37,7 +37,7 @@ For information about pagination in Search responses, see xref:server:fts:fts-se
 == Index Creation
 
 For the purposes of the below examples we will use the Beer Sample sample bucket.
-Full Text Search indexes can be xref:{version-server}@server:fts:fts-creating-indexes.adoc[created through the UI or throuth the REST API], or created programatically as follows:
+The Search indexes can be xref:{version-server}@server:fts:fts-creating-indexes.adoc[created through the UI or throuth the REST API], or created programatically as follows:
 
 [source,ruby]
 ----
@@ -50,7 +50,7 @@ include::example$search.rb[tag=index]
 In versions of Couchbase Server starting from 7.6, Search queries are executed at either the Scope or the Cluster level;
 in earlier versions, they are just performed at the cluster level. (not bucket or collection). 
 
-We will perform an FTS query here - see the <<vector search>> section for examples of that.
+We will perform an Search query here - see the <<vector search>> section for examples of that.
 Here is a simple query that looks for the text "hop beer" using the defined index:
 
 [source,ruby]
@@ -106,9 +106,9 @@ include::example$search.rb[tag=facet,]
 
 == Scoped vs Global Indexes
 
-The FTS APIs exist at both the `Cluster` and `Scope` levels.
+The Search APIs exist at both the `Cluster` and `Scope` levels.
 
-This is because FTS supports, as of Couchbase Server 7.6, a new form of "scoped index" in addition to the traditional "global index".
+This is because the Search Service supports, as of Couchbase Server 7.6, a new form of "scoped index" in addition to the traditional "global index".
 
 It's important to use the `Cluster.searchQuery()` / `Cluster.search()` for global indexes, and `Scope.search()` for scoped indexes.
 
@@ -123,7 +123,7 @@ The `SearchQuery` is created in the same way as detailed earlier.
 
 == Consistency
 
-Like the xref:n1ql-queries-with-sdk.adoc#scan-consistency[Couchbase Query Service], FTS allows `consistent_with()` queries -- _Read-Your-Own_Writes (RYOW)_ consistency,
+Like the xref:n1ql-queries-with-sdk.adoc#scan-consistency[Couchbase Query Service], the Search Service allows `consistent_with()` queries -- _Read-Your-Own_Writes (RYOW)_ consistency,
 ensuring results contain information from updated indexes:
 
 [source,ruby]

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -155,7 +155,7 @@ xref:concept-docs:transactions.adoc[multi-document ACID transactions].
 
 
 
-== Retrieving full documents
+== Retrieving Full Documents
 
 Using the `.get()` method with the document key can be done in a similar fashion to the other operations:
 
@@ -279,11 +279,11 @@ TIP: KV range scan is suitable for use cases that require relatively low concurr
 If your application does many scans at once, or requires low latency results, we recommend using {sqlpp} (with a primary index on the collection) instead of KV range scan.
 
 [#kv-range-scan-range]
-=== Range scan
+=== Range Scan
 
 Here's an example of a KV range scan that gets all documents in a collection:
 
-.KV Range Scan for all documents in a collection
+.KV Range Scan for all Documents in a Collection
 [source,ruby]
 ----
 include::example$kv_operations.rb[tag=range-scan-all-documents, indent=0]
@@ -296,7 +296,7 @@ Instead, it's more common to use the "prefix" scan type shown in the next exampl
 
 
 [#kv-range-scan-prefix]
-=== Prefix scan
+=== Prefix Scan
 
 KV range scan can also give you all documents whose IDs start with the same prefix.
 Imagine you have a collection where documents are named like this: `<username>::<uuid>`.
@@ -317,18 +317,18 @@ include::example$kv_operations.rb[tag=range-scan-prefix, indent=0]
 
 If you want to get random documents from a collection, use a sample scan.
 
-.KV Range Scan for 100 random documents
+.KV Range Scan for 100 Random Documents
 [source,ruby]
 ----
 include::example$kv_operations.rb[tag=range-scan-sample, indent=0]
 ----
 
 [#kv-range-scan-only-ids]
-=== Get IDs instead of full documents
+=== Get IDs Instead of Full Documents
 
 If you only want the document IDs, set the `ids_only` attribute of `Options::Scan` to `true`, like this:
 
-.KV Range Scan for all document IDs in a collection
+.KV Range Scan for all Document IDs in a Collection
 [source,ruby]
 ----
 include::example$kv_operations.rb[tag=range-scan-all-document-ids, indent=0]

--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -115,7 +115,7 @@ include::example$Transcoding.java[tag=gson-decode,indent=0]
 It is most common to store JSON with Couchbase.
 However, it is possible to store non-JSON documents, such as raw binary data, perhaps using an concise binary encoding like https://msgpack.org[MessagePack] or https://cbor.io/[CBOR], in the Key-Value store.
 
-NOTE: It's important to note that the Couchbase Data Platform includes multiple components other than the Key-Value store -- including Query and its indexes, FTS, analytics, and eventing -- and these are optimized for JSON and will either ignore or provide limited functionality with non-JSON documents.
+NOTE: It's important to note that the Couchbase Data Platform includes multiple components other than the Key-Value store -- including Query and its indexes, Search Service, analytics, and eventing -- and these are optimized for JSON and will either ignore or provide limited functionality with non-JSON documents.
 
 Also note that some simple data types can be stored directly as JSON, without recourse to non-JSON transcoding.
 A valid JSON document can be a simple integer (`42`), string (`"hello"`), array (`[1,2,3]`), boolean (`true`, `false`) and the JSON `null` value.
@@ -259,7 +259,7 @@ include::example$Transcoding.java[tag=msgpack-encode,indent=0]
 
 // * For _Common flags_, setting the data format used, see the xref:ref:data-structures.adoc#common-flags[Data Structures reference].
 // * _Format flags_ for ancient SDKs are still available for compatibility, if you are porting a long-lived legacy app. See the xref:ref:data-structures.adoc#legacy-formats[Legacy formats reference].
-* If you want to work with binary documents and our Search service, you might like to take a look at https://github.com/khanium/couchbase-fts-binary
+* If you want to work with binary documents and our Search Service, you might like to take a look at https://github.com/khanium/couchbase-fts-binary
 
 
 

--- a/modules/howtos/pages/vector-searching-with-sdk.adoc
+++ b/modules/howtos/pages/vector-searching-with-sdk.adoc
@@ -90,7 +90,7 @@ This can be more efficient, unless you are doing a lot of optimization to your q
 
 == Vector Search With the Search Service
 
-Vector search is also implemented using xref:full-text-searching-with-sdk.adoc[Search Indexes], and can be combined with traditional search queries.
+Vector search is also implemented using xref:full-text-searching-with-sdk.adoc[Search Indexes], and can be combined with traditional Search queries.
 Vector embeddings can be an array of floats or a xref:server:vector-search:run-vector-search-ui.adoc#base64[base64 encoded string].
 
 === Prerequisites

--- a/modules/howtos/pages/vector-searching-with-sdk.adoc
+++ b/modules/howtos/pages/vector-searching-with-sdk.adoc
@@ -90,7 +90,7 @@ This can be more efficient, unless you are doing a lot of optimization to your q
 
 == Vector Search With the Search Service
 
-Vector search is also implemented using xref:full-text-searching-with-sdk.adoc[Search Indexes], and can be combined with traditional full text search queries.
+Vector search is also implemented using xref:full-text-searching-with-sdk.adoc[Search Indexes], and can be combined with traditional search queries.
 Vector embeddings can be an array of floats or a xref:server:vector-search:run-vector-search-ui.adoc#base64[base64 encoded string].
 
 === Prerequisites


### PR DESCRIPTION
[DOC-14062](https://jira.issues.couchbase.com/browse/DOC-14062)

Changed the FTS instances to Search.

[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-ruby-DOC-14062_Ruby_FTS_to_Search_Namechange)

[DOC-14062]: https://couchbasecloud.atlassian.net/browse/DOC-14062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ